### PR TITLE
Fahrenheit unit representation fix

### DIFF
--- a/docs/C/IfcConversionBasedUnitWithOffset.md
+++ b/docs/C/IfcConversionBasedUnitWithOffset.md
@@ -22,7 +22,7 @@ IfcConversionBasedUnitWithOffset(
 >     THERMODYNAMICTEMPERATUREUNIT,  
 >     ''Fahrenheit'',  
 >     IfcMeasureWithUnit(  
->         IfcThermodynamicTemperatureMeasure(1.8),  
+>         IfcThermodynamicTemperatureMeasure(1/1.8),  
 >         IfcSiUnit(THERMODYNAMICTEMPERATUREUNIT, ?, KELVIN)),  
 >     -459.67);  
   


### PR DESCRIPTION
The example provided to demonstrate a usage of IfcConversionBasedUnitWithOffset to represent Fahrenheit unit is wrong. 

Reasoning:
The description of the IfcConversionBasedUnit::ConversionFactor attribute states that this conversion factor is "The physical quantity from which the converted unit is derived." I interpret this statement as "the number of Kelvin degrees needed to change a Fahrenheit measured value by 1 degree". This interpretation goes in line with examples provided for other IfcConversionBasedUnits. Please refer to examples at https://standards.buildingsmart.org/IFC/RELEASE/IFC4/ADD2/HTML/annex/annex-e/basic-unit-declaration.htm. There you can see that, for example, the INCH unit is stated as the following:
#3=IFCSIUNIT (*, .LENGTHUNIT., .MILLI., .METRE.);
#7=IFCCONVERSIONBASEDUNIT(#9, .LENGTHUNIT., 'INCH', #8);
#8=IFCMEASUREWITHUNIT(IFCLENGTHMEASURE(25.4), #3);
This obviously means that |1INCH|=|25.4mm|. The same is correct for other conversion based units. 
Similarly we can state that |1F|=|K/1.8| and so the Fahrenheit unit's conversion factor should be 1/1.8 and not 1.8. The difference becomes more obvious when trying to apply a single algorithm/formula for measure unit transformation: this wrong Fahrenheit unit alone does not fit such algorithms.