### PR TITLE
bring back IFC4.0.2.1 text removing standard case

### DIFF
--- a/docs/schemas/shared/IfcSharedBldgElements/Entities/IfcBeam.md
+++ b/docs/schemas/shared/IfcSharedBldgElements/Entities/IfcBeam.md
@@ -2,20 +2,21 @@
 
 An _IfcBeam_ is a horizontal, or nearly horizontal, structural member that is capable of withstanding load primarily by resisting bending. It represents such a member from an architectural point of view. It is not required to be load bearing.
 
-{ .extDef}
 > NOTE&nbsp; Definition according to ISO 6707-1: structural member for carrying load(s) between or beyond points of support, usually narrow in relation to its length and horizontal or nearly so.
 
-> NOTE&nbsp; The representation of load-bearing beams in a structural analysis model is provided by subtypes of _IfcStructuralMember_ (with _IfcStructuralCurveMember_ being mostly applicable) as part of an _IfcStructuralAnalysisModel_.
+There are two main representations for beam occurrences:
 
-> NOTE&nbsp; For any other longitudinal structural member, not constrained to be predominately horizontal nor vertical, or where this semantic information is irrelevant, the entity _IfcMember_ should be used.
+- _IfcBeam_ with _IfcMaterialProfileSetUsage_ is used for all occurrences of beams, that have a profile defined that is swept along a directrix. The profile might be changed uniformly by a taper definition along the directrix. The profile parameter and its cardinal point of insertion can be fully described by the _IfcMaterialProfileSetUsage_. These beams are always represented geometricly by an 'Axis' and a 'SweptSolid' or 'AdvancedSweptSolid' shape representation (or by a 'Clipping' geometry based on the swept solid), if a 3D geometric representation is assigned.
 
-The camber of a beam may be defined by assigning a StructuralCurveMember with displacement coordinates. Multiple sets of camber ordinates may be provided that are qualified by the particular load case, where full dead load would typically be used for fabrication, and other scenarios used for other loading conditions such as during construction.
+- _IfcBeam_ without _IfcMaterialProfileSetUsag_e is used for all other occurrences of beams, particularly for beams with non-uniformly changing profile sizes along the sweep, or beams having only 'AdvancedBrep', 'Brep', or 'SurfaceModel' geometry, or if a more parametric representation is not intended.
 
-There are two entities for beam occurrences:
+> NOTE  The entity IfcBeamStandardCase has been deprecated, IfcBeam with IfcMaterialProfileSetUsage is used instead.
 
-* _IfcBeamStandardCase_ used for all occurrences of beams, that have a profile defined that is swept along a directrix. The profile might be changed uniformly by a taper definition along the directrix. The profile parameter and its cardinal point of insertion can be fully described by the _IfcMaterialProfileSetUsage_. These beams are always represented geometricly by an 'Axis' and a 'SweptSolid' or 'AdvancedSweptSolid' shape representation (or by a 'Clipping' geometry based on the swept solid), if a 3D geometric representation is assigned. In addition they have to have a corresponding _IfcMaterialProfileSetUsage_ assigned. 
->> NOTE&nbsp; Model view definitions and implementer agreements may further constrain the applicable geometry types, for example, by excluding tapering from an _IfcBeamStandardCase_ implementation.* _IfcBeam_ used for all other occurrences of beams, particularly for beams with non-uniformly changing profile sizes along the sweep, or beams having only 'AdvancedBrep', 'Brep', 'SurfaceModel', or 'Tessellation' geometry. 
->> NOTE&nbsp; Model view definitions and implementer agreements may impose the use of _IfcBeam_ in all cases by excluding _IfcBeamStandardCase_ from scope of the model view.
+For any other longitudinal structural member, not constrained to be predominately horizontal nor vertical, or where this semantic information is irrelevant, the entity _IfcMember_ should be used.
+
+> NOTE&nbsp; The representation of load-bearing beams in a structural analysis model is provided by subtypes of _IfcStructuralMember_ (with _IfcStructuralCurveMember_ being mostly applicable) as part of an _IfcStructuralAnalysisModel_. The camber of a beam may be defined by assigning an _IfcStructuralCurveMember_ with displacement coordinates. Multiple sets of camber ordinates may be provided that are qualified by the particular load case, where full dead load would typically be used for fabrication, and other scenarios used for other loading conditions such as during construction.
+
+
 > HISTORY&nbsp; New entity in IFC1.0
 
 ## Attributes
@@ -45,12 +46,12 @@ The axis representation can be used to represent the system
 
 
 
-> NOTE  The 'Axis' is used to locate the 
+> NOTE  The 'Axis' is used to locate the
 > material profile set, if the material association is of type IfcMaterialProfileSetUsage.
 
 
 The following additional constraints apply to the 'Axis'
-representation, if an IfcMaterialProfileSetUsage is provided and the 'Body' shape representation has the 
+representation, if an IfcMaterialProfileSetUsage is provided and the 'Body' shape representation has the
 RepresentationType: 'SweptSolid':
 
 
@@ -139,7 +140,7 @@ The following additional constraints apply to the 'SweptSolid' representation ty
 
 * Solid: IfcExtrudedAreaSolid,
 IfcRevolvedAreaSolid shall be supported
-* Profile: all subtypes of IfcProfileDef (with 
+* Profile: all subtypes of IfcProfileDef (with
 exception of IfcArbitraryOpenProfileDef)
 * Extrusion:  All extrusion directions shall be
 supported.
@@ -165,14 +166,14 @@ Figure 201 — Beam non-perpendicular extrusion
 
 ### Material Profile Set
 
-The material information of the IfcBeam is defined by 
+The material information of the IfcBeam is defined by
 IfcMaterialProfileSet or as fallback by IfcMaterial, and it is attached either directly or at the IfcBeamType. In this case, the material information does not allow to construct a shape by applying the profile definition to the axis representation, to enable this parametric definition, the IfcMaterialProfileSetUsage has to be used instead.
 
 
 
 ### Material Profile Set Usage
 
-The Material Profile Set Usage defines the assignment of an IfcMaterialProfileSetUsage to the 
+The Material Profile Set Usage defines the assignment of an IfcMaterialProfileSetUsage to the
 IfcBeamType providing a common profile definition to all
  occurrences of this IfcBeamType. Beams with composite profile can be represented by refering to
  several IfcMaterialProfile's within the
@@ -234,10 +235,9 @@ Figure 198 — Beam composite profiles
 
 ### Spatial Containment
 
-The IfcBeam, as any subtype of IfcBuildingElement, 
+The IfcBeam, as any subtype of IfcBuildingElement,
 may participate alternatively in one of the two different containment relationships:
 
 
 * the Spatial Containment (defined here), or
 * the Element Composition.
-

--- a/docs/schemas/shared/IfcSharedBldgElements/Entities/IfcColumn.md
+++ b/docs/schemas/shared/IfcSharedBldgElements/Entities/IfcColumn.md
@@ -1,20 +1,21 @@
 # IfcColumn
 
-<An _IfcColumn_ is a vertical structural member which often is aligned with a structural grid intersection. It represents a vertical, or nearly vertical, structural member that transmits, through compression, the weight of the structure above to other structural elements below. It represents such a member from an architectural point of view. It is not required to be load bearing.
+An _IfcColumn_ is a vertical structural member which often is aligned with a structural grid intersection. It represents a vertical, or nearly vertical, structural member that transmits, through compression, the weight of the structure above to other structural elements below. It represents such a member from an architectural point of view. It is not required to be load bearing.
 
-{ .extDef}
 > NOTE&nbsp; Definition according to ISO 6707-1  
 > structural member of slender form, usually vertical, that transmits to its base the forces, primarily in compression, that are applied to it.
 
+There are two main representations for column occurrences:
+
+- _IfcColumn_ with _IfcMaterialProfileSetUsage_ is used for all occurrences of columns, that have a profile defined that is swept along a directrix. The profile might be changed uniformly by a taper definition along the directrix. The profile parameter and its cardinal point of insertion can be fully described by the _IfcMaterialProfileSetUsag_e. These columns are always represented geometricly by an 'Axis' and a 'SweptSolid' or 'AdvancedSweptSolid' shape representation (or by a 'Clipping' geometry based on the swept solid), if a 3D geometric representation is assigned.
+
+- _IfcColumn_ is used for all other occurrences of columns, particularly for columns with changing profile sizes along the extrusion, or columns defined by non-linear extrusion, or columns having only 'Brep', or 'SurfaceModel' geometry, or if a more parametric representation is not intended.
+
+> NOTE  The entity IfcColumnStandardCase has been deprecated, IfcColumn with IfcMaterialProfileSetUsage is used instead.
+
+For any longitudial structural member, not constrained to be predominately horizontal nor vertical, or where this semantic information is irrelevant, the entity _IfcMember_ exists.
+
 > NOTE&nbsp; The representation of a column in a structural analysis model is provided by _IfcStructuralCurveMember_ being part of an _IfcStructuralAnalysisModel_.
-
-> NOTE&nbsp; For any longitudial structural member, not constrained to be predominately horizontal nor vertical, or where this semantic information is irrelevant, the entity _IfcMember_ exists.
-
-The IFC specification provides two entities for column occurrences:
-
-* _IfcColumnStandardCase_ used for all occurrences of columns, tthat have a profile defined that is swept along a directrix. The profile might be changed uniformly by a taper definition along the directrix. The profile parameter and its cardinal point of insertion can be fully described by the _IfcMaterialProfileSetUsage_. These beams are always represented geometricly by an 'Axis' and a 'SweptSolid' or 'AdvancedSweptSolid' shape representation (or by a 'Clipping' geometry based on the swept solid), if a 3D geometric representation is assigned. In addition they have to have a corresponding _IfcMaterialProfileSetUsage_ assigned. 
->> NOTE&nbsp; View definitions and implementer agreements may further constrain the applicable geometry types, for example by excluding tapering from an _IfcColumnStandardCase_ implementation. 
-* _IfcColumn_ used for all other occurrences of columns, particularly for columns with changing profile sizes along the extrusion, or columns defined by non-linear extrusion, or columns having only 'Brep', or 'SurfaceModel' geometry.
 
 > HISTORY&nbsp; New entity in IFC1.0
 
@@ -45,12 +46,12 @@ The axis representation can be used to represent the system
 
 
 
-> NOTE  The 'Axis' is used to locate the 
+> NOTE  The 'Axis' is used to locate the
 > material profile set, if the material association is of type IfcMaterialProfileSetUsage.
 
 
 The following additional constraints apply to the 'Axis'
-representation, if an IfcMaterialProfileSetUsage is provided and the 'Body' shape representation has the 
+representation, if an IfcMaterialProfileSetUsage is provided and the 'Body' shape representation has the
 RepresentationType: 'SweptSolid':
 
 
@@ -180,9 +181,9 @@ IfcMaterialProfileSet or as fallback by IfcMaterial, and it is attached either d
 
 ### Material Profile Set Usage
 
-The Material Profile Set Usage defines the assignment of an IfcMaterialProfileSetUsage to the 
+The Material Profile Set Usage defines the assignment of an IfcMaterialProfileSetUsage to the
 IfcColumnType providing a common profile definition to all
- occurrences of this IfcColumnType. Columns with 
+ occurrences of this IfcColumnType. Columns with
 composite profile can be represented by refering to
  several IfcMaterialProfile's within the
 IfcMaterialProfileSet that is referenced from the
@@ -200,7 +201,7 @@ Figure 212 illustrates cardinal point alignment.
 
 
 
-> NOTE  It has to be guaranteed that the use of IfcCardinalPointEnum is consistent to the placement of the 
+> NOTE  It has to be guaranteed that the use of IfcCardinalPointEnum is consistent to the placement of the
 > extrusion body provided by IfcExtrudedAreaSolid.Position
 
 
@@ -232,10 +233,9 @@ Figure 213 — Column composite profiles
 
 ### Spatial Containment
 
-The IfcColumn, as any subtype of IfcBuildingElement, 
+The IfcColumn, as any subtype of IfcBuildingElement,
 may participate alternatively in one of the two different containment relationships:
 
 
 * the Spatial Containment (defined here), or
 * the Element Composition.
-

--- a/docs/schemas/shared/IfcSharedBldgElements/Entities/IfcDoor.md
+++ b/docs/schemas/shared/IfcSharedBldgElements/Entities/IfcDoor.md
@@ -2,7 +2,6 @@
 
 The door is a built element that is predominately used to provide controlled access for people, goods, animals and vehicles. It includes constructions with hinged, pivoted, sliding, and additionally revolving and folding operations.
 
-{ .extDef}
 > NOTE&nbsp; Definition according to ISO 6707-1: construction for closing an opening, intended primarily for access with hinged, pivoted or sliding operation.  
 
 The _IfcDoor_ defines a particular occurrence of a door inserted in the spatial context of a project. A door can:  
@@ -14,14 +13,15 @@ The _IfcDoor_ defines a particular occurrence of a door inserted in the spatial 
 
 This specification provides two main representations for door occurrences:  
 
-* _IfcDoor_ used for all occurrences of doors, that have a 'Profile' shape representation defined to which a set of shape parameters for lining and framing properties apply. Additionally it requires the provision of an _IfcDoorType_ that references one _IfcDoorLiningProperties_ and on to many _IfcDoorPanelProperties_;
+* _IfcDoor_ used for all occurrences of doors, that have a 'Profile' shape representation defined to which a set of shape parameters for lining and framing properties apply. Additionally it requires the provision of an _IfcDoorType_ that references one _IfcDoorLiningProperties_ and one to many _IfcDoorPanelProperties_;
 > NOTE&nbsp; The entity _IfcDoorStandardCase_ has been deprecated.
+
 * _IfcDoor_ used for all other occurrences of doors, particularly for doors having only 'Brep', or 'SurfaceModel' geometry without applying shape parameters.
 
-  
-The actual parameters of the door and/or its shape are defined by the _IfcDoor_ as the occurrence definition (or project instance), or by the _IfcDoorType_ as the specific definition (or project type). The following parameters are given: 
 
-* at the _IfcDoor_ or _IfcDoorStandardCase_ for occurrence specific parameters. The _IfcDoor_ specifies:
+The actual parameters of the door and/or its shape are defined by the _IfcDoor_ as the occurrence definition or by the _IfcDoorType_ as the object type definition. The following parameters are provided:
+
+* at the _IfcDoor_ for occurrence specific parameters. The _IfcDoor_ specifies:
     * the door width and height
     * the door opening direction (by the y-axis of the _ObjectPlacement_)
 * at the _IfcDoorType_, to which the _IfcDoor_ is related by the inverse relationship _IsTypedBy_ pointing to _IfcRelDefinesByType_, for type parameters common to all occurrences of the same type.
@@ -29,19 +29,19 @@ The actual parameters of the door and/or its shape are defined by the _IfcDoor_ 
     * the door hinge side (by using two different styles for right and left opening doors)
     * the construction material type
     * the particular attributes for the lining by the _IfcDoorLiningProperties_
-    * the particular attributes for the panels by the _IfcDoorPanelProperties_ 
+    * the particular attributes for the panels by the _IfcDoorPanelProperties_
 
 > HISTORY&nbsp; New entity in IFC1.0.
 
 { .change-ifc2x4}
 > IFC4 CHANGE&nbsp; The attributes _PredefinedType_ and _OperationType_ are added, the applicable type object has been changed to _IfcDoorType_.
-  
+
 The geometric representation of _IfcDoor_ is given by the _IfcProductDefinitionShape_, allowing multiple geometric representations. The _IfcDoor_ may get its parameter and shape from the _IfcDoorType_. If an _IfcRepresentationMap_ (a block definition) is defined for the _IfcDoorType_, then the _IfcDoor_ inserts it through the _IfcMappedItem_.  
 
 The geometric representation of _IfcDoor_ is defined using the following (potentially multiple) _IfcShapeRepresentation_'s for its _IfcProductDefinitionShape_:  
 
 * **Profile**: A 'Curve3D' consisting of a single losed curve defining the outer boundary of the door (lining). The door parametric representation uses this profile in order to apply the door lining and panel parameter. If not provided, the profile of the _IfcOpeningElement_ is taken.
-* **FootPrint**: A 'GeometricCurveSet', or 'Annotation2D' representation defining the 2D shape of the door 
+* **FootPrint**: A 'GeometricCurveSet', or 'Annotation2D' representation defining the 2D shape of the door
 * **Body**: A 'SweptSolid', 'SurfaceModel', or 'Brep' representation defining the 3D shape of the door.
 
 In addition the parametric representation of a (limited) door shape is available by applying the parameters from _IfcDoorType_ referencing _IfcDoorLiningProperties_ and _IfcDoorPanelProperties_. The purpose of the parameter is described at those entities and below (door opening operation by door type).  
@@ -84,16 +84,16 @@ Either there is no door type object associated, i.e. the _IsTypedBy_ inverse rel
 ### Door Attributes
 
 The opening direction is determined by the local placement of
-IfcDoor and the OperationType of the IfcDoorType as 
-shown in Figure 228. 
+IfcDoor and the OperationType of the IfcDoorType as
+shown in Figure 228.
 
 The IfcDoorTypeOperationEnum defines the general layout of the door type and its symbolic presentation. Depending on the enumerator, the appropriate instances of IfcDoorLiningProperties and IfcDoorPanelProperties are attached in the list of HasPropertySets. The IfcDoorTypeOperationEnum mainly determines the hinge side (left hung, or right hung), the operation (swinging, sliding, folding, etc.) and the number of panels.
 
 
 
-> NOTE  There are different definitions 
+> NOTE  There are different definitions
 > in various countries on what a left opening or left hung or left
-> swing door is (same for right). Therefore the IFC definition may 
+> swing door is (same for right). Therefore the IFC definition may
 > derivate from the local standard and need to be mapped
 > appropriately.
 
@@ -107,35 +107,35 @@ standards
 The door panel (for swinging doors) opens
 always into the direction of the positive Y axis of the local
 placement. The determination of whether the door opens to the left
-or to the right is done at the level of the IfcDoorType. 
-Here it is a left side opening door given 
-by IfcDoorType.OperationType = 
+or to the right is done at the level of the IfcDoorType.
+Here it is a left side opening door given
+by IfcDoorType.OperationType =
 SingleSwingLeft
 refered to as LEFT HAND (LH) in US *  
 
-  
+
 
 refered to as DIN-R (right hung) in Germany
 ![fig 2](../../../../figures/ifcdoor-fig02.gif)
 If the door should open to the other side,
-then the local placement has to be changed. It is still a left side 
+then the local placement has to be changed. It is still a left side
 opening door, given by IfcDoorType.OperationType =
  SingleSwingLeft
 refered to as RIGHT HAND REVERSE (RHR) in
 US *  
 
-  
+
 
 refered to as DIN-R (right hung) in Germany
 ![fig 3](../../../../figures/ifcdoor-fig03.gif)
 If the door panel (for swinging doors)
 opens to the right, a separate door style needs to be used (here
-IfcDoorTypee.OperationType = SingleSwingRight) and it always 
+IfcDoorTypee.OperationType = SingleSwingRight) and it always
 opens into the direction of the positive Y axis of the local
 placement.
 refered to as RIGHT HAND (RH) in US *  
 
-  
+
 
 refered to as DIN-L (left hung) in Germany
 ![fig 4](../../../../figures/ifcdoor-fig04.gif)
@@ -146,7 +146,7 @@ IfcDoorType.OperationType = SingleSwingRight.
 refered to as LEFT HAND REVERSE (LHR) in US
 *  
 
-  
+
 
 refered to as DIN-L (left hung) in Germany
 * it assumes that the
@@ -166,7 +166,7 @@ Figure 228 — Door swing
 ### Material Constituent Set
 
 The material of the IfcDoor is defined by the
-IfcMaterialConstituentSet or as fall back by 
+IfcMaterialConstituentSet or as fall back by
 IfcMaterial and attached by the
 IfcRelAssociatesMaterial relationship. It is accessible by the inverse HasAssociations relationship.
 
@@ -216,15 +216,15 @@ level.
 ### Profile 3D Geometry
 
 The door profile is represented by a three-dimensional closed
-curve within a particular shape representation. The profile is used 
+curve within a particular shape representation. The profile is used
 to apply the parameter of the parametric door representation. The
- following attribute values for the IfcShapeRepresentation 
+ following attribute values for the IfcShapeRepresentation
 holding this geometric representation shall be used:
 
 
 * RepresentationIdentifier : 'Profile'
 * RepresentationType : 'Curve3D' or 'GeometricCurveSet',
-in case of 'GeometricCurveSet' only a single closed curve shall be 
+in case of 'GeometricCurveSet' only a single closed curve shall be
 contained in the set of IfcShapeRepresentation.Items.
 
 
@@ -250,7 +250,7 @@ IfcCartesianPoint's shall be 0.).
 
 
 
-> 
+>
 > * IfcDoorLiningProperties.LiningDepth starting at distance
 > defined by LiningOffset going into the positive y
 > direction.
@@ -264,11 +264,11 @@ IfcCartesianPoint's shall be 0.).
 > * IfcDoorLiningProperties.ThresholdDepth starting at
 > distance defined by LiningOffset going into the positive y
 > direction.
-> * IfcDoorLiningProperties.TransomOffset starting at the 
+> * IfcDoorLiningProperties.TransomOffset starting at the
 > bottom edge of the rectangle (along local x axis) into the inner
 > side of the rectangle, distance provided as percentage of overall
 > height. Distance to the centre line of the transom.
-> 
+>
 
 
 Figure 229 — Door profile
@@ -287,7 +287,7 @@ Figure 229 — Door profile
 
 ### Spatial Containment
 
-The IfcDoor, as any subtype of IfcBuildingElement, 
+The IfcDoor, as any subtype of IfcBuildingElement,
 may participate alternatively in one of the two different containment relationships:
 
 
@@ -302,7 +302,7 @@ The IfcDoor may also be connected to the IfcOpeningElement in which it is placed
 
 > NOTE  The containment shall be
 > defined independently of the filling relationship, that is, even if
-> 
+>
 >  the IfcDoor is a filling of an opening established by
 > IfcRelFillsElement, it is also contained in the spatial
 > structure by
@@ -314,6 +314,3 @@ Figure 230 — Door spatial containment
 
 
  
-
-
-

--- a/docs/schemas/shared/IfcSharedBldgElements/Entities/IfcMember.md
+++ b/docs/schemas/shared/IfcSharedBldgElements/Entities/IfcMember.md
@@ -2,13 +2,14 @@
 
 An _IfcMember_ is a structural member designed to carry loads between or beyond points of support. It is not required to be load bearing. The orientation of the member (being horizontal, vertical or sloped) is not relevant to its definition (in contrary to _IfcBeam_ and _IfcColumn_). An _IfcMember_ represents a linear structural element from an architectural or structural modeling point of view and shall be used if it cannot be expressed more specifically as either an _IfcBeam_ or an _IfcColumn_.
 
+There are two main representations for member occurrences:
+
+- _IfcMember_ with _IfcMaterialProfileSetUsage_ is used for all occurrences of members, that have a profile defined that is swept along a directrix. The profile might be changed uniformly by a taper definition along the directrix. The profile parameter and its cardinal point of insertion can be fully described by the _IfcMaterialProfileSetUsage_. These members are always represented geometricly by an 'Axis' and a 'SweptSolid' or 'AdvancedSweptSolid' shape representation (or by a 'Clipping' geometry based on the swept solid), if a 3D geometric representation is assigned.
+
+- _IfcMember_ without _IfcMaterialProfileSetUsage_ is used for all other occurrences of members, particularly for members with changing profile sizes along the extrusion, or members defined by non-linear extrusion, or members having only 'Brep', or 'SurfaceModel' geometry, or if a more parametric representation is not intended.
+
+
 > NOTE&nbsp; The representation of a member in a structural analysis model is provided by _IfcStructuralCurveMember_ being part of an _IfcStructuralAnalysisModel_.
-
-The IFC specification provides two entities for member occurrences:
-
-* _IfcMemberStandardCase_ used for all occurrences of members, that have a profile defined that is swept along a directrix. The profile might be changed uniformly by a taper definition along the directrix. The profile parameter and its cardinal point of insertion can be fully described by the _IfcMaterialProfileSetUsage_. These beams are always represented geometricly by an 'Axis' and a 'SweptSolid' or 'AdvancedSweptSolid' shape representation (or by a 'Clipping' geometry based on the swept solid), if a 3D geometric representation is assigned. In addition they have to have a corresponding _IfcMaterialProfileSetUsage_ assigned. 
->> NOTE&nbsp; View definitions and implementer agreements may further constrain the applicable geometry types, such as by excluding tapering from an _IfcMemberStandardCase_ implementation. 
-* _IfcMember_ used for all other occurrences of members, particularly for members with changing profile sizes along the extrusion, or members defined by non-linear extrusion, or members having only 'Brep', or 'SurfaceModel' geometry.
 
 > HISTORY&nbsp; New entity in IFC2x2 Addendum 1.
 
@@ -39,12 +40,12 @@ The axis representation can be used to represent the system
 
 
 
-> NOTE  The 'Axis' is used to locate the 
+> NOTE  The 'Axis' is used to locate the
 > material profile set, if the material association is of type IfcMaterialProfileSetUsage.
 
 
 The following additional constraints apply to the 'Axis'
-representation, if an IfcMaterialProfileSetUsage is provided and the 'Body' shape representation has the 
+representation, if an IfcMaterialProfileSetUsage is provided and the 'Body' shape representation has the
 RepresentationType: 'SweptSolid':
 
 
@@ -138,7 +139,7 @@ representation
 
 ### Body Clipping Geometry
 
-The following constraints apply to the 'Clipping' 
+The following constraints apply to the 'Clipping'
 representation:
 
 
@@ -160,7 +161,7 @@ Figure 238 illustrates a 'Clipping' geometric representation with use of IfcBool
 Figure 238 — Member clipping
 
 
-The following constraints apply to the 'Clipping' 
+The following constraints apply to the 'Clipping'
 representation, when an IfcMaterialProfileSetUsage is assigned to the IfcMember:
 
 
@@ -196,7 +197,7 @@ The following constraints apply to the 'SweptSolid' representation:
 * Extrusion: All extrusion directions shall be supported.
 
 
-<>The following additional constraints apply to the 'SweptSolid' 
+<>The following additional constraints apply to the 'SweptSolid'
 representation, when an IfcMaterialProfileSetUsage is assigned to the IfcMember:
 
 * Solid: IfcExtrudedAreaSolid,
@@ -204,7 +205,7 @@ IfcRevolvedAreaSolid shall be supported
 * Profile: all subtypes of IfcProfileDef (with
 exception of IfcArbitraryOpenProfileDef)
 * Profile Position : For all single profiles, the
- IfcParameterizedProfileDef.Position shall be NIL, or 
+ IfcParameterizedProfileDef.Position shall be NIL, or
 having Location = 0.,0. and RefDirection =
 1.,0.
 * Extrusion: perpendicular to the profile
@@ -249,7 +250,7 @@ The material information of the IfcMember is defined by the
 
 The material of the IfcMember is defined by
 IfcMaterialProfileSetUsage and attached by the
-IfcRelAssociatesMaterial.RelatingMaterial. It is 
+IfcRelAssociatesMaterial.RelatingMaterial. It is
 accessible by the inverse HasAssociations relationship.
  Composite profile members can be represented by refering to
 several IfcMaterialProfile's within the
@@ -284,10 +285,9 @@ Figure 234 — Member composite profiles
 
 ### Spatial Containment
 
-The IfcMember, as any subtype of IfcBuildingElement, 
+The IfcMember, as any subtype of IfcBuildingElement,
 may participate alternatively in one of the two different containment relationships:
 
 
 * the Spatial Containment (defined here), or
 * the Element Composition.
-

--- a/docs/schemas/shared/IfcSharedBldgElements/Entities/IfcPlate.md
+++ b/docs/schemas/shared/IfcSharedBldgElements/Entities/IfcPlate.md
@@ -2,25 +2,26 @@
 
 An _IfcPlate_ is a planar and often flat part with constant thickness. A plate may carry loads between or beyond points of support, or provide stiffening. The location of the plate (being horizontal, vertical or sloped) is not relevant to its definition (in contrary to _IfcWall_ and _IfcSlab_ (as floor slab)).
 
-{ .extDef}
 > NOTE&nbsp; Definition according to ISO 6707-1: thin, rigid, flat, metal product, of a thickness greater than that of a sheet.
 
 Plates are normally made of steel, other metallic material, or by glass panels. However the definition of _IfcPlate_ is material independent and specific material information shall be handled by using _IfcAssociatesMaterial_ to assign a material specification to the _IfcPlate_.
 
 > NOTE&nbsp; Although not necessarily, plates are often add-on parts. This is represented by the _IfcRelAggregates_ decomposition mechanism used to aggregate parts, such as _IfcPlate_, into a container element such as _IfcElementAssembly_ or _IfcCurtainWall_.
 
-> NOTE&nbsp; The representation of a plate in a structural analysis model is provided by _IfcStructuralSurfaceMember_ being part of an _IfcStructuralAnalysisModel_.
-
-An instance _IfcPlate_ should preferably get its geometric representation and material assignment through the type definition by _IfcPlateType_ assigned using the _IfcRelDefinesByType_ relationship. This allows identical plates in a construction to be represented by the same instance of _IfcPlateType_.
+An instance of _IfcPlate_ should preferably get its geometric representation and material assignment through the type definition by _IfcPlateType_ assigned using the _IfcRelDefinesByType_ relationship. This allows identical plates in a construction to be represented by the same instance of _IfcPlateType_.
 
 A plate may have openings, such as voids or recesses. They are defined by an _IfcOpeningElement_ attached to the plate using the inverse relationship _HasOpenings_ pointing to _IfcRelVoidsElement_. The position number of a plate as often used in steel construction is assigned through the attribute _IfcElement.Tag_
 
-The IFC specification provides two entities for plate occurrences:
+There are two main representations for plate occurrences:
 
-* _IfcPlateStandardCase_ used for all occurrences of plates, that are prismatic and where the thickness parameter can be fully described by the _IfcMaterialLayerSetUsage_. These plates are always represented geometrically by a 'SweptSolid' geometry (or by a 'Clipping' geometry based on 'SweptSolid'), if a 3D geometric representation is assigned. In addition they have to have a corresponding _IfcMaterialLayerSetUsage_ assigned.
-* _IfcPlate_ used for all other occurrences of plates, particularly for plates with changing thickness, or plates with non planar surfaces, and plates having only 'SurfaceModel' or 'Brep' geometry.
+- _IfcPlate_ with _IfcMaterialLayerSetUsage_ is used for all occurrences of plates, that are prismatic and where the thickness parameter can be fully described by the _IfcMaterialLayerSetUsage_. These plates are always represented geometrically by a 'SweptSolid' geometry (or by a 'Clipping' geometry based on 'SweptSolid'), if a 3D geometric representation is assigned.
+
+- _IfcPlate_ without _IfcMaterialLayerSetUsage_ is used for all other occurrences of plates, particularly for plates with changing thickness, or plates with non planar surfaces, and plates having only 'SurfaceModel' or 'Brep' geometry or if a more parametric representation is not intended.
+
+> NOTE&nbsp; The representation of a plate in a structural analysis model is provided by _IfcStructuralSurfaceMember_ being part of an _IfcStructuralAnalysisModel_.
 
 > HISTORY&nbsp; New entity in IFC2x2
+
 
 ## Attributes
 
@@ -43,7 +44,7 @@ Either there is no plate type object associated, i.e. the _IsTypedBy_ inverse re
 
 ### Body Clipping Geometry
 
-The following constraints apply to the 'Clipping' 
+The following constraints apply to the 'Clipping'
 representation when an IfcMaterialLayerSetUsage is assigned to the IfcPlate:
 
 
@@ -77,7 +78,7 @@ Figure 248 — Plate body clipping
 
 ### Body SweptSolid Geometry
 
-The following additional constraints apply to the 'SweptSolid' 
+The following additional constraints apply to the 'SweptSolid'
 representation:
 
 
@@ -93,7 +94,7 @@ or non-perpendicularly to the plane of the swept profile.
 
 
 
-The following additional constraints apply to the 'SweptSolid' 
+The following additional constraints apply to the 'SweptSolid'
 representation, when an IfcMaterialLayerSetUsage is assigned to the IfcPlate:
 
 
@@ -134,20 +135,20 @@ The material information of the IfcPlate is defined by
 
 ### Material Layer Set Usage
 
-The material of IfcPlate can be defined by 
-IfcMaterialLayerSetUsage and attached by 
+The material of IfcPlate can be defined by
+IfcMaterialLayerSetUsage and attached by
 IfcRelAssociatesMaterial.RelatingMaterial. It is
  accessible by the inverse HasAssociations relationship.
- Multi-layer plates can be represented by refering to several 
-IfcMaterialLayer's within the IfcMaterialLayerSet 
+ Multi-layer plates can be represented by refering to several
+IfcMaterialLayer's within the IfcMaterialLayerSet
 that is referenced from the
 IfcMaterialLayerSetUsage.
 
 
-When assigning an 
+When assigning an
 IfcMaterialLayerSetUsage to IfcPlate it shall imply that the
  IfcPlateType should have a unique
- IfcMaterialLayerSet, that is referenced by IfcMaterialLayerSetUsage assigned to all 
+ IfcMaterialLayerSet, that is referenced by IfcMaterialLayerSetUsage assigned to all
 occurrences of this IfcPlateType.
 
 
@@ -187,7 +188,7 @@ Figure 247 — Plate material layers
 
 ### Spatial Containment
 
-The IfcPlate, as any subtype of IfcBuildingElement, 
+The IfcPlate, as any subtype of IfcBuildingElement,
 may participate alternatively in one of the two different containment relationships:
 
 
@@ -197,9 +198,6 @@ may participate alternatively in one of the two different containment relationsh
 ### Surface 3D Geometry
 
 
-> NOTE  The 'Surface' can be used to define a 
+> NOTE  The 'Surface' can be used to define a
 > surfacic model of the building (e.g. for analytical purposes, or
 > for reduced Level of Detail representation).
-
-
-

--- a/docs/schemas/shared/IfcSharedBldgElements/Entities/IfcSlab.md
+++ b/docs/schemas/shared/IfcSharedBldgElements/Entities/IfcSlab.md
@@ -2,23 +2,26 @@
 
 A slab is a component of the construction that may enclose a space vertically. The slab may provide the lower support (floor) or upper construction (roof slab) in any space in a building.
 
-{ .extDef}
 > NOTE&nbsp; Definition according to ISO 6707-1  
 > thick, flat or shaped component, usually larger than 300 mm square, used to form a covering or projecting from a building.
 
 Only the core or constructional part of this construction is considered to be a slab. The upper finish (flooring, roofing) and the lower finish (ceiling, suspended ceiling) are considered to be coverings. A special type of slab is the landing, described as a floor section to which one or more stair flights or ramp flights connect.
 
-> NOTE&nbsp; There is a representation of slabs for structural analysis provided by a proper subtype of _IfcStructuralMember_ being part of the _IfcStructuralAnalysisModel_.
-
 > NOTE&nbsp; An arbitrary planar element to which this semantic information is not applicable or irrelevant shall be modeled as _IfcPlate_.
 
 A slab may have openings, such as floor openings, or recesses. They are defined by an _IfcOpeningElement_ attached to the slab using the inverse relationship _HasOpenings_ pointing to _IfcRelVoidsElement_.
 
-There are three entities for slab occurrences:
+> NOTE&nbsp; Slabs with openings that have already been modeled within the enclosing geometry may use the relationship _IfcRelConnectsElements_ to associate the wall with embedded elements such as trap doors.
 
-* _IfcSlabStandardCase_ used for all occurrences of slabs, that are prismatic and where the thickness parameter can be fully described by the _IfcMaterialLayerSetUsage_. These slabs are always represented geometrically by a 'SweptSolid' geometry (or by a 'Clipping' geometry based on 'SweptSolid'), if a 3D geometric representation is assigned. In addition they have to have a corresponding _IfcMaterialLayerSetUsage_ assigned.
-* _IfcSlabElementedCase_ used for occurrences of slabs which are aggregated from subordinate elements, following specific decomposition rules expressed by the mandatory use of _IfcRelAggregates_ relationship.
-* _IfcSlab_ used for all other occurrences of slabs, particularly for slabs with changing thickness, or slabs with non planar surfaces, and slabs having only 'SweptSolid' or 'Brep' geometry.
+There are two main representations for slab occurrences:
+
+- _IfcSlab_ with _IfcMaterialLayerSetUsage_ is used for all occurrences of slabs, that are prismatic and where the thickness parameter can be fully described by the _IfcMaterialLayerSetUsage_. These slabs are always represented geometrically by a 'SweptSolid' geometry (or by a 'Clipping' geometry based on 'SweptSolid'), if a 3D geometric representation is assigned.
+
+- _IfcSlab_ without _IfcMaterialLayerSetUsage_ is used for all other occurrences of slabs, particularly for slabs with changing thickness, or slabs with non planar surfaces, and slabs having only 'SweptSolid' or 'Brep' geometry, or if a more parametric representation is not intended.
+
+> NOTE The entity _IfcSlabStandardCase_ has been deprecated, _IfcSlab_ with _IfcMaterialLayerSetUsage_ is used instead. The entity _IfcSlabElementedCase_ has been deprecated, _IfcSlab_ with _IfcRelAggregates_ is used to describe occurrences of slabs which are aggregated from subordinate elements.
+
+> NOTE There is a representation of slabs for structural analysis provided by a proper subtype of _IfcStructuralMember_ being part of the _IfcStructuralAnalysisModel_.
 
 > HISTORY&nbsp; New entity in IFC2.0; it is a merger of the two previous entities IfcFloor, IfcRoofSlab, introduced in IFC1.0
 
@@ -98,12 +101,12 @@ Figure 267 — Slab body clipping
 
 ### Body SweptSolid Geometry
 
-The following constraints apply to the 'SweptSolid' 
+The following constraints apply to the 'SweptSolid'
 representation:
 
 
 * Solid: IfcExtrudedAreaSolid is required,
-* Profile: IfcArbitraryClosedProfileDef, 
+* Profile: IfcArbitraryClosedProfileDef,
 IfcRectangleProfileDef, IfcCircleProfileDef ,
 IfcEllipseProfileDef shall be supported.
 * Extrusion: The profile can be extruded perpendicularly
@@ -116,28 +119,28 @@ Figure 264 illustrates a 'SweptSolid' geometric representation.
 
 > NOTE  The following interpretation of dimension parameter applies for polygonal slabs (in ground floor view):
 > * IfcArbitraryClosedProfileDef.OuterCurve: closed bounded curve interpreted as area (or foot print) of the slab.
-> 
-> 
-> 
+>
+>
+>
 
 
 ![standard slab](../../../../figures/ifcslab_standard-layout1.gif)
 Figure 264 — Slab body extrusion
 
 
-The following additional constraints apply to the 'SweptSolid' 
+The following additional constraints apply to the 'SweptSolid'
 representation, when an IfcMaterialLayerSetUsage is assigned to the IfcSlab:
 
 
 * Solid: IfcExtrudedAreaSolid is required,
-* Profile: IfcArbitraryClosedProfileDef, 
-IfcRectangleProfileDef, IfcCircleProfileDef, 
+* Profile: IfcArbitraryClosedProfileDef,
+IfcRectangleProfileDef, IfcCircleProfileDef,
 IfcEllipseProfileDef shall be supported.
 * Extrusion: The profile can be extruded perpendicularly
 or non-perpendicularly to the plane of the swept profile.
 * Material: The definition of the
- IfcMaterialLayerSetUsage, particularly of the 
-OffsetFromReferenceLine and the 
+ IfcMaterialLayerSetUsage, particularly of the
+OffsetFromReferenceLine and the
 ForLayerSet.TotalThickness, has to be consistent to the
 'SweptSolid' representation.
 
@@ -167,20 +170,20 @@ The material information of the IfcSlab is defined by
 
 ### Material Layer Set Usage
 
-The material of IfcSlab can be defined by 
-IfcMaterialLayerSetUsage and attached by 
+The material of IfcSlab can be defined by
+IfcMaterialLayerSetUsage and attached by
 IfcRelAssociatesMaterial.RelatingMaterial. It is
  accessible by the inverse HasAssociations relationship.
- Multi-layer slabs can be represented by refering to several 
-IfcMaterialLayer's within the IfcMaterialLayerSet 
+ Multi-layer slabs can be represented by refering to several
+IfcMaterialLayer's within the IfcMaterialLayerSet
 that is referenced from th e
 IfcMaterialLayerSetUsage.
 
 
-When assigning an 
+When assigning an
 IfcMaterialLayerSetUsage to IfcSlab it shall imply that the
  IfcSlabType should have a unique
- IfcMaterialLayerSet, that is referenced by IfcMaterialLayerSetUsage assigned to all 
+ IfcMaterialLayerSet, that is referenced by IfcMaterialLayerSetUsage assigned to all
 occurrences of this IfcSlabType.
 
 
@@ -223,7 +226,7 @@ Figure 263 — Slab material layers
 
 ### Spatial Containment
 
-The IfcSlab, as any subtype of IfcBuildingElement, 
+The IfcSlab, as any subtype of IfcBuildingElement,
 may participate alternatively in one of the two different containment relationships:
 
 
@@ -236,6 +239,3 @@ may participate alternatively in one of the two different containment relationsh
 > NOTE  The 'Surface' can be used to define a
 > surfacic model of the building (e.g. for analytical purposes, or
 > for reduced Level of Detail representation).
-
-
-

--- a/docs/schemas/shared/IfcSharedBldgElements/Entities/IfcWall.md
+++ b/docs/schemas/shared/IfcSharedBldgElements/Entities/IfcWall.md
@@ -5,19 +5,21 @@ The wall represents a vertical construction that may bound or subdivide spaces. 
 { .extDef}
 > NOTE&nbsp; Definition according to ISO 6707-1: vertical construction usually in masonry or in concrete which bounds or subdivides a construction works and fulfils a load bearing or retaining function.
 
-> NOTE&nbsp; There is a representation of walls for structural analysis provided by a proper subtype of _IfcStructuralMember_ being part of the _IfcStructuralAnalysisModel_.
-
 > NOTE&nbsp; An arbitrary planar element to which this semantic information is not applicable (is not predominantly vertical), shall be modeled as _IfcPlate_.
 
 A wall may have openings, such as wall openings, openings used for windows or doors, or niches and recesses. They are defined by an _IfcOpeningElement_ attached to the wall using the inverse relationship _HasOpenings_ pointing to _IfcRelVoidsElement_.
 
 > NOTE&nbsp; Walls with openings that have already been modeled within the enclosing geometry may use the relationship _IfcRelConnectsElements_ to associate the wall with embedded elements such as doors and windows.
 
-There are three entities for wall occurrences:
+There are two main representations for all occurrences:
 
-* _IfcWallStandardCase_  used for all occurrences of walls, that have a non-changing thickness along the wall path and where the thickness parameter can be fully described by a material layer set. These walls are always represented geometrically by an 'Axis' and a 'SweptSolid' shape representation (or by a 'Clipping' geometry based on 'SweptSolid'), if a 3D geometric representation is assigned. In addition they have to have a corresponding _IfcMaterialProfileSetUsage_ assigned.
-* _IfcWallElementedCase_ used for occurrences of walls which are aggregated from subordinate elements, following specific decomposition rules expressed by the mandatory use of _IfcRelAggregates_ relationship.
-* _IfcWall_  used for all other occurrences of wall, particularly for walls with changing thickness along the wall path (e.g. polygonal walls), or walls with a non-rectangular cross sections (e.g. L-shaped retaining walls), and walls having an extrusion axis that is unequal to the global Z axis of the project (i.e. non-vertical walls), or walls having only 'Brep', or 'SurfaceModel' geometry.
+- _IfcWall_ with _IfcMaterialLayerSetUsage_ is used for all occurrences of walls, that have a non-changing thickness along the wall path and where the thickness parameter can be fully described by a material layer set. These walls are always represented geometrically by an 'Axis' and a 'SweptSolid' shape representation (or by a 'Clipping' geometry based on 'SweptSolid'), if a 3D geometric representation is assigned.
+
+- _IfcWall_ without _IfcMaterialLayerSetUsage_ is used for all other occurrences of wall, particularly for walls with changing thickness along the wall path (e.g. polygonal walls), or walls with a non-rectangular cross sections (e.g. L-shaped retaining walls), and walls having an extrusion axis that is unequal to the global Z axis of the project (i.e. non-vertical walls), or walls having only 'Brep', or 'SurfaceModel' geometry, or if a more parametric representation is not intended.
+
+> NOTE  The entity _IfcWallStandardCase_ has been deprecated, _IfcWall_ with _IfcMaterialLayerSetUsage_ is used instead. The entity _IfcWallbElementedCase_ has been deprecated, _IfcWall_ with _IfcRelAggregates_ is used to describe occurrences of wall which are aggregated from subordinate elements, such as wall panels.
+
+> NOTE&nbsp; There is a representation of walls for structural analysis provided by a proper subtype of _IfcStructuralMember_ being part of the _IfcStructuralAnalysisModel_.
 
 > HISTORY&nbsp; New entity in IFC1.0
 
@@ -42,23 +44,23 @@ Either there is no wall type object associated, i.e. the _IsTypedBy_ inverse rel
 
 ### Axis 2D Geometry
 
-The wall axis is represented by a two-dimensional open curve 
-within a particular shape representation. The 'Axis' shape representation is only used to locate the 
-material layer set along the axis, if the IfcMaterialLayerSetUsgae is applied to the IfcWall. In this case, the wall axis is used to 
+The wall axis is represented by a two-dimensional open curve
+within a particular shape representation. The 'Axis' shape representation is only used to locate the
+material layer set along the axis, if the IfcMaterialLayerSetUsgae is applied to the IfcWall. In this case, the wall axis is used to
 apply the material layer set usage parameter to the wall geometry.
 
 
 
 * Axis
-	+ IfcPolyline having two Points, or 
+	+ IfcPolyline having two Points, or
 	IfcTrimmedCurve with BasisCurve of Type
-	IfcLine for the 'SweptSolid' provided as 
+	IfcLine for the 'SweptSolid' provided as
 	IfcExtrudedAreaSolid. The axis curve lies on the x/y plane and is parallel to the x-axis of
 	 the object coordinate system.
 	+ IfcTrimmedCurve with BasisCurve of Type
 	IfcCircle for 'SweptSolid' provided as
 	 IfcExtrudedAreaSolid. The axis curve lies on the x/y plane
-	 of the object coordinate system, the tangent at the start is along 
+	 of the object coordinate system, the tangent at the start is along
 	the positive x-axis.
 
 
@@ -95,7 +97,7 @@ Figure 280 — Wall axis curved
 
 ### Body Clipping Geometry
 
-The following additional constraints apply to the 'SweptSolid' 
+The following additional constraints apply to the 'SweptSolid'
 representation, when an IfcMaterialLayerSetUsage is assigned to the IfcSlab:
 
 
@@ -136,11 +138,11 @@ representation:
 * Solid: IfcExtrudedAreaSolid is required,
 * Profile: IfcArbitraryClosedProfileDef is
 required.
-* Extrusion: All extrusion directions shall be 
+* Extrusion: All extrusion directions shall be
 supported.
 
 
-The following additional constraints apply to the 'SweptSolid' 
+The following additional constraints apply to the 'SweptSolid'
 representation, when an IfcMaterialLayerSetUsage is assigned to the IfcSlab:
 
 
@@ -184,20 +186,20 @@ The material information of the IfcWall is defined by
 
 ### Material Layer Set Usage
 
-The material of IfcWall can be defined by 
-IfcMaterialLayerSetUsage and attached by 
+The material of IfcWall can be defined by
+IfcMaterialLayerSetUsage and attached by
 IfcRelAssociatesMaterial.RelatingMaterial. It is
  accessible by the inverse HasAssociations relationship.
- Multi-layer walls can be represented by refering to several 
-IfcMaterialLayer's within the IfcMaterialLayerSet 
+ Multi-layer walls can be represented by refering to several
+IfcMaterialLayer's within the IfcMaterialLayerSet
 that is referenced from the
  IfcMaterialLayerSetUsage.
 
 
-When assigning an 
+When assigning an
 IfcMaterialLayerSetUsage to IfcWall it shall imply that the
  IfcWallType should have a unique
- IfcMaterialLayerSet, that is referenced by IfcMaterialLayerSetUsage assigned to all 
+ IfcMaterialLayerSet, that is referenced by IfcMaterialLayerSetUsage assigned to all
 occurrences of this IfcWallType.
 
 
@@ -244,7 +246,7 @@ Figure 278 — Wall material layers
 
 ### Spatial Containment
 
-The IfcWall, as any subtype of IfcBuildingElement, 
+The IfcWall, as any subtype of IfcBuildingElement,
 may participate alternatively in one of the two different containment relationships:
 
 
@@ -257,6 +259,3 @@ may participate alternatively in one of the two different containment relationsh
 > NOTE  The 'Surface' can be used to define a
 > surfacic model of the building (e.g. for analytical purposes, or
 > for reduced Level of Detail representation).
-
-
-

--- a/docs/schemas/shared/IfcSharedBldgElements/Entities/IfcWindow.md
+++ b/docs/schemas/shared/IfcSharedBldgElements/Entities/IfcWindow.md
@@ -14,25 +14,26 @@ The _IfcWindow_ defines a particular occurrence of a window inserted in the spat
 
 > NOTE&nbsp; View definitions or implementer agreements may restrict the relationship to only include one window (or door) into one opening.
 
-There are two entities for window occurrences:
+There are two main representations for window occurrences:
 
-* _IfcWindowStandardCase_ used for all occurrences of windows, that have a 'Profile' shape representation defined to which a set of shape parameters for lining and framing properties apply. Additionally it requires the provision of an _IfcWindowType_ that references one _IfcWindowLiningProperties_ and on to many _IfcWindowPanelProperties_. 
-* _IfcWindow_ used for all other occurrences of windows, particularly for windows having only 'Brep', or 'SurfaceModel' geometry without applying shape parameters.
+- _IfcWindow_ with a shape representation having RepresentationIdenfifier='Profile' is used for all occurrences of windows, that have a 'Profile' shape representation defined to which a set of shape parameters for lining and framing properties apply. Additionally it requires the provision of an _IfcWindowType_ that references one _IfcWindowLiningProperties_ and on to many _IfcWindowPanelProperties_.
+
+- _IfcWindow_ used for all other occurrences of windows, particularly for windows having only 'Brep', or 'SurfaceModel' geometry without applying shape parameters.
+
+> NOTE  The entity _IfcWindowStandardCase_ has been deprecated.
 
 The actual parameter of the window and/or its shape is defined at the _IfcWindow_ as the occurrence definition (or project instance), or by the _IfcWindowType_ as the specific definition (or project type). The following parameters are given:
 
 * at the _IfcWindow_ or _IfcWindowStandardCase_ for occurrence specific parameters. The _IfcWindow_ specifies:
-*  
     * the window width and height
-    * the window opening direction (by the y-axis of the _ObjectPlacement_) 
+    * the window opening direction (by the y-axis of the _ObjectPlacement_)
 * at the _IfcWindowType_ to which the _IfcWindow_ is related by the inverse relationship _IsDefinedBy_ pointing to _IfcRelDefinesByType_, for type parameters common to all occurrences of the same type.
-*  
     * the partitioning type (single panel, double panel, tripel panel, more panels)
     * the operation type (swing, tilt and turn, pivot revolve, fixed case ment, etc.)
     * the window panel hinge side (by using two different styles for right and left opening windows)
     * the construction material type
     * the particular attributes for the lining by the _IfcWindowLiningProperties_
-    * the particular attributes for the panels by the  _IfcWindowPanelProperties_ 
+    * the particular attributes for the panels by the  _IfcWindowPanelProperties_
 
 > HISTORY&nbsp; New entity in IFC1.0.
 
@@ -42,7 +43,7 @@ The actual parameter of the window and/or its shape is defined at the _IfcWindow
 { .use-head}
 Parameteric Representation using parameters at _IfcWindowType_
 
-The parameters, which define the shape of the _IfcWindow_, are given at the _IfcWindowType_ and the property sets, which are included in the _IfcWindowType_. The _IfcWindow_ only defines the local placement. The overall size of the _IfcWindow_ to be used to apply the lining or panel parameter provided by the _IfcWindowType_ is determined by the IfcShapeRepresentation with the RepresentationIdentifier = 'Profile'. Only in case of an _IfcWindow_ inserted into an _IfcOpeningElement_ using the _IfcRelFillsElement_ relatioship, having a horizontal extrusion (along the y-axis of the _IfcDoor_), the overall size is determined by the extrusion profile of the _IfcOpeningElement_.
+The parameters, which define the shape of the _IfcWindow_, are given at the _IfcWindowType_ and the property sets, which are included in the _IfcWindowType_. The _IfcWindow_ only defines the local placement. The overall size of the _IfcWindow_ to be used to apply the lining or panel parameter provided by the _IfcWindowType_ is determined by the IfcShapeRepresentation with the RepresentationIdentifier = 'Profile'. Only in case of an _IfcWindow_ inserted into an _IfcOpeningElement_ using the _IfcRelFillsElement_ relatioship, having a horizontal extrusion (along the y-axis of the _IfcWindow_), the overall size is determined by the extrusion profile of the _IfcOpeningElement_.
 
 Figure 1 illustrates the insertion of a window into the _IfcOpeningElement_ by creating an instance of _IfcWindow_ with _PartitioningType = DoublePanelHorizontal_. The parameters _OverallHeight_ and _OverallWidth_ show the extent of the window in the positive Z and X axis of the local placement of the window. The lining and the transom are created by the given parameters.
 
@@ -113,12 +114,12 @@ window, given by <em>IfcWindowPanelProperties.OperationType</em>
 ## Attributes
 
 ### OverallHeight
-Overall measure of the height, it reflects the Z Dimension of a bounding box, enclosing the window opening. If omitted, the _OverallHeight_ should be taken from the geometric representation of the _IfcOpening_ in which the window is inserted. 
+Overall measure of the height, it reflects the Z Dimension of a bounding box, enclosing the window opening. If omitted, the _OverallHeight_ should be taken from the geometric representation of the _IfcOpening_ in which the window is inserted.
 
 > NOTE&nbsp; The body of the window might be taller then the window opening (for example in cases where the window lining includes a casing). In these cases the _OverallHeight_ shall still be given as the window opening height, and not as the total height of the window lining.
 
 ### OverallWidth
-Overall measure of the width, it reflects the X Dimension of a bounding box, enclosing the window opening. If omitted, the _OverallWidth_ should be taken from the geometric representation of the _IfcOpening_ in which the window is inserted. 
+Overall measure of the width, it reflects the X Dimension of a bounding box, enclosing the window opening. If omitted, the _OverallWidth_ should be taken from the geometric representation of the _IfcOpening_ in which the window is inserted.
 
 > NOTE&nbsp; The body of the window might be wider then the window opening (for example in cases where the window lining includes a casing). In these cases the _OverallWidth_ shall still be given as the window opening width, and not as the total width of the window lining.
 
@@ -130,7 +131,7 @@ Predefined generic type for a window that is specified in an enumeration. There 
 > IFC4 CHANGE The attribute has been added at the end of the entity definition.
 
 ### PartitioningType
-Type defining the general layout of the window in terms of the partitioning of panels. 
+Type defining the general layout of the window in terms of the partitioning of panels.
 > NOTE&nbsp; The _PartitioningType_ shall only be used, if no type object _IfcWindowType_ is assigned, providing its own _IfcWindowType.PartitioningType_.
 
 { .change-ifc2x4}
@@ -202,7 +203,7 @@ is defined within the world coordinate system.
 ### Profile 3D Geometry
 
 The window profile is represented by a three-dimensional
-closed curve within a particular shape representation. The 
+closed curve within a particular shape representation. The
 profile is used to apply the parameter of the parametric window
 representation. The following attribute values for the
 IfcShapeRepresentation holding this geometric
@@ -210,7 +211,7 @@ representation shall be used:
 
 
 * RepresentationIdentifier : 'Profile'
-* RepresentationType : 'Curve3D', only a single closed 
+* RepresentationType : 'Curve3D', only a single closed
 curve shall be contained in the set of
 IfcShapeRepresentation.Items.
 
@@ -226,7 +227,7 @@ A 'Profile' representation has to be provided if:
 	window profile)
 
 
-The following additional constraints apply to the 'Profile' 
+The following additional constraints apply to the 'Profile'
 representation type:
 
 
@@ -274,7 +275,7 @@ Figure 298 — Window profile
 
 ### Spatial Containment
 
-The IfcWindow, as any subtype of IfcBuildingElement, 
+The IfcWindow, as any subtype of IfcBuildingElement,
 may participate alternatively in one of the two different containment relationships:
 
 
@@ -287,8 +288,8 @@ The IfcWindow may also be connected to the IfcOpeningElement in which it is plac
 
 ![Containment](../../../../figures/ifcwindow_containment-01.png)
 
-> NOTE  The containment shall be defined independently of the filling relationship, that is, even if the 
->  IfcWindow is a filling of an opening established by IfcRelFillsElement, it is also contained in the spatial structure 
+> NOTE  The containment shall be defined independently of the filling relationship, that is, even if the
+>  IfcWindow is a filling of an opening established by IfcRelFillsElement, it is also contained in the spatial structure
 >  by an IfcRelContainedInSpatialStructure.
 
 
@@ -306,5 +307,3 @@ IfcWindowLiningProperties and IfcWindowPanelProperties are attached in the list 
 
 
 See IfcWindowTypePartitioningEnum for the correct usage of panel partitioning and IfcWindowPanelProperties for the opening symbols for different panel operation types.
-
-


### PR DESCRIPTION
adding back the textual changes in IFC4.0.2.1 to remove the explanations of standard case and elemented case as option in the documentation of the "main" building elements.