### PR TITLE
Update IfcLibraryReference.md

### DIFF
--- a/docs/schemas/resource/IfcExternalReferenceResource/Entities/IfcLibraryReference.md
+++ b/docs/schemas/resource/IfcExternalReferenceResource/Entities/IfcLibraryReference.md
@@ -9,7 +9,7 @@ Depending on the type of technology used by the library, different IfcLibraryRef
 Publisher | Technology | Identifier
 --- | --- | ---
 ASHRAE | BACnet | 32-bit decimal BACnetObjectIdentifier indicating type ID and instance ID (e.g.'12.15' for Digital Input #15).
-Brick Development Team | Brick | Full URI with no namespace (e.g. 'http://example.org/digitaltwin#AHU01')
+Brick Development Team | Brick | Full URI with no abbreviation (e.g. 'http://example.org/digitaltwin#AHU01', not 'digitaltwin:AHU01')
 IETF | IPv4 | 32-bit decimal address for an IPv4 network (e.g.'192.168.1.1').
 IETF | IPv6 | 128-bit hexadecimal address for an IPv6 network.
 IETF | MAC | 48-bit hexadecimal form of MAC address.


### PR DESCRIPTION
Clarify description of identifier for Brick URIs. All URIs can be said to have a namespace; what we want to avoid is having an abbreviation that we can't resolve to the full URI. The easiest way to handle this is just to mandate the full URI is provided. Let me know if this is sufficient or if there is more information you'd like me to add!

(by the way, the new documentation is *amazing* -- congrats to the team!)