### PR TITLE
IfcCylindricalSurface typo

### DIFF
--- a/docs/schemas/resource/IfcGeometryResource/Entities/IfcCylindricalSurface.md
+++ b/docs/schemas/resource/IfcGeometryResource/Entities/IfcCylindricalSurface.md
@@ -9,7 +9,7 @@ The cylindrical surface is a surface unbounded in the direction of _z_. Bounded 
 The inherited attributes are interpreted as
 
 * _SELF\IfcElementarySurface.Position_ defines the location and orientation of the cylindrical surface.
-* _SELF\IfcElementarySurface.Position.Location_ definesd a point on the axis of the cylindrical surface.
+* _SELF\IfcElementarySurface.Position.Location_ defines a point on the axis of the cylindrical surface.
 * _SELF\IfcElementarySurface.Position.P[3]_ defines the direction of the axis of the cylindrical surface.
 
 { .extDef}


### PR DESCRIPTION
A very small typo in [docs/schemas/resource/IfcGeometryResource/Entities/IfcCylindricalSurface.md](https://github.com/buildingSMART/IFC4.3.x-development/compare/master...FoxySeta:patch-1#diff-08de551c36550e8e2106d78531f04154e17389eb29b8ce7523b6c33dba9e3331). I suppose automatic spellcheckers are not suited for this kind of documents.