### PR TITLE
No nested quotes in IfcSurfaceOfLinearExtrusion.md

### DIFF
--- a/docs/schemas/resource/IfcGeometryResource/Entities/IfcSurfaceOfLinearExtrusion.md
+++ b/docs/schemas/resource/IfcGeometryResource/Entities/IfcSurfaceOfLinearExtrusion.md
@@ -5,9 +5,10 @@ The _IfcSurfaceOfLinearExtrusion_ is a surface derived by sweeping a curve along
 { .extDef}
 > NOTE  Definition according to ISO/CD 10303-42:1992
 > This surface is a simple swept surface or a generalized cylinder obtained by sweeping a curve in a given direction. The parameterization is as follows where the curve has a parameterization &lambda;(_u_):
->> V = ExtrusionAxis
->>
->> ![Image](../../../../figures/ifcsurfaceoflinearextrusion-math1.gif)
+>
+> V = ExtrusionAxis
+>
+> ![Image](../../../../figures/ifcsurfaceoflinearextrusion-math1.gif)
 >  The parameterization range for _v_ is -&infin; < _v_ < &infin; and for _u_ it is defined by the curve parameterization.
 
 > NOTE  Entity adapted from **surface_of_linear_extrusion** defined in ISO 10303-42.


### PR DESCRIPTION
Nested quotes appear to get discarded during the HTML docs generation. I temporarily "flattened" them into a single, plain quote. Please feel free to commit more refined patches in my own branch. Thanks in advance!