### PR TITLE
Fix missing Quantity Sets in toc.html

### DIFF
--- a/code/server.py
+++ b/code/server.py
@@ -1879,7 +1879,7 @@ def annex_a_psd():
 
 
 def annotate_hierarchy(data=None, start=1, number_path=None):
-    level_2_headings = ("Schema Definition", "Types", "Entities", "Property Sets", "Functions", "Rules")
+    level_2_headings = ("Schema Definition", "Types", "Entities", "Property Sets", "Quantity Sets", "Functions", "Rules")
 
     def items(d):
         if len(number_path or []) == 2:


### PR DESCRIPTION
The Contents page doesn't include Quantity Sets, and the chapter numbering is therefore also wrong. This commit includes Quantity Sets in the toc.html ("Contents") page.