### PR TITLE
Changed input pset xml path in generate_pset_template.py

### DIFF
--- a/code/generate_pset_templates.py
+++ b/code/generate_pset_templates.py
@@ -27,7 +27,7 @@ import sys
 
 BASE_MODULE_PATH = Path(__file__).parent
 IFC4x3_HTML_LOCATION = BASE_MODULE_PATH / "IFC4.3-html-iso-release"
-IFC4x3_PSD_LOCATION = BASE_MODULE_PATH / "psd"
+IFC4x3_PSD_LOCATION = BASE_MODULE_PATH / "../output/psd"
 
 try:
     IFC4x3_OUTPUT_PATH = sys.argv[1]


### PR DESCRIPTION
Missed it in #594 - had wrong path in `generate_pset_template.py` resulting in 
```
Starting parsing data for IFC4X3...
0 psets parsed.
```
in the [build](https://app.travis-ci.com/github/buildingSMART/IFC4.3.x-development/builds/261148292) and empty psets library - https://github.com/buildingSMART/IFC4.3.x-output/blob/49cdeffdcd83db7509e99a16062e9f748d0c6ecf/Pset_IFC4X3.ifc


Tested this one, now it's working - https://app.travis-ci.com/github/buildingSMART/IFC4.3.x-development/builds/261399113#L3374