### PR TITLE
NBN-102 Update element openings relationship

### DIFF
--- a/code/concept_interpretation.py
+++ b/code/concept_interpretation.py
@@ -109,7 +109,7 @@ concept_type.SIMPLE_UNARY,
 ('FootPrint Geometry', ('Identifier', ('IfcShapeRepresentation', 'RepresentationIdentifier')), ('Items', ('IfcShapeRepresentation', 'Items')), ('Type', ('IfcShapeRepresentation', 'RepresentationType'))):
 concept_type.SIMPLE_UNARY,
 ('Element Openings', ('FillsVoids', ('IfcOpeningElement', 'FillsVoids')), ('HasOpenings', ('IfcElement', 'HasOpenings')), ('OpeningElementType', ('IfcOpeningElement', 'PredefinedType')), ('RelatedBuiltElement', ('IfcRelFillsElement', 'RelatedBuildingElement')), ('RelatedOpeningElement', ('IfcRelVoidsElement', 'RelatedOpeningElement'))):
-concept_type.SIMPLE_UNARY,
+concept_type.DIRECTIONAL_BINARY,
 ('Product Linear Placement', ('HasPlacement', ('IfcProduct', 'ObjectPlacement')), ('LinearPositioningElementName', ('IfcLinearPositioningElement', 'Name')), ('RelativePlacement', ('IfcLinearPlacement', 'RelativePlacement')), ('RelativeToElement', ('IfcLocalPlacement', 'PlacesObject'))):
 concept_type.SIMPLE_UNARY,
 ('Element Voiding Features', ('HasOpenings', ('IfcElement', 'HasOpenings')), ('RelatedVoidingFeature', ('IfcRelVoidsElement', 'RelatedOpeningElement')), ('VoidingFeatureType', ('IfcVoidingFeature', 'PredefinedType'))):

--- a/docs/templates/Object Attributes/Software Identity/README.md
+++ b/docs/templates/Object Attributes/Software Identity/README.md
@@ -3,7 +3,9 @@ Software Identity
 
 An object needs to be identifiable for accurate processing by both human and automated processes. Identification may be through several attributes such as Identification, Name, Description or GUID. The GUID is compressed for the purpose of being exchanged within an IFC data set - the compressed GUID is referred to as "IFC-GUID". While the IFC-GUID is normally generated automatically and has to be persistent, the Identification may relate to other informal registers but should be unique within the set of objects of the same type. The Name and Description should allow any object to be identified in the context of the project or facility being modelled.
 
-Various objects may have additional identifications that may be human-readable and/or may be structured through classification association. Various file formats may use additional identifications of instances for serialization purposes, however there is no requirement or guarantee for such identifications to remain the same between revisions or across applications. For example, the IFC-SPF file format lists each instance with a 64-bit integer that is unique within the particular file.
+Various objects may have additional identifications that may be human-readable and/or may be structured through classification association. Various file formats may use additional identifications of instances for serialization purposes, however there is no requirement or guarantee for such identifications to remain the same between revisions or across applications.
+
+> EXAMPLE the IFC-SPF file format lists each instance with a positive integer that is unique within a particular file. In the code example that follows that is the number 123. Contrary to the _GlobalId_ attribute, this is *not* intended as a stable identifier accross repeated exchanges or reserializations. `#123=IFCPERSON($,$,'Alice',$,$,$,$,$);`
 
 ```
 concept {

--- a/docs/templates/Object Composition/Element Voiding/Element Openings/README.md
+++ b/docs/templates/Object Composition/Element Voiding/Element Openings/README.md
@@ -9,16 +9,16 @@ The 'Reference' representation of an element does account for voids at export, s
 
 ```
 concept {
-    IfcElement_0:HasOpenings -> IfcRelVoidsElement:RelatingBuildingElement
-    IfcRelVoidsElement:RelatedOpeningElement -> IfcOpeningElement
-IfcOpeningElement:PredefinedType -> IfcOpeningElementTypeEnum
-    IfcOpeningElement:FillsVoids -> IfcRelFillsElement:RelatedBuildingElement
-    IfcRelFillsElement:RelatedBuildingElement -> IfcElement_1
+    IfcElement:HasOpenings -> IfcRelVoidsElement:RelatingBuildingElement
+    IfcRelVoidsElement:RelatedOpeningElement -> IfcOpeningElement:VoidsElements
+    IfcOpeningElement:PredefinedType -> IfcOpeningElementTypeEnum
+    IfcOpeningElement:HasFillings -> IfcRelFillsElement:RelatingOpeningElement
+    IfcRelFillsElement:RelatedBuildingElement -> IfcElement_1:FillsVoids
 
-    IfcElement_1:HasOpenings[binding="HasOpenings"]
+    IfcElement_1:FillsVoids[binding="FillsVoids"]
     IfcRelVoidsElement:RelatedOpeningElement[binding="RelatedOpeningElement"]
     IfcOpeningElement:PredefinedType[binding="OpeningElementType"]
-    IfcOpeningElement:FillsVoids[binding="FillsVoids"]
+    IfcOpeningElement:HasFillings[binding="HasFillings"]
     IfcRelFillsElement:RelatedBuildingElement[binding="RelatedBuiltElement"]
 }
 ```

--- a/docs/templates/Object Composition/Element Voiding/Element Openings/README.md
+++ b/docs/templates/Object Composition/Element Voiding/Element Openings/README.md
@@ -3,9 +3,9 @@ Element Openings
 
 Elements may have openings (geometric voids) defined, which may be a partial recess or extend the full depth. Openings may optionally be filled by another element such as a door or window.
 
-The 'Body' representation of an element does not account for voids, for which CSG operations are required to produce the resulting shape.
+The 'Body' representation of an element does not account for voids upon export, for which CSG operations are required at import to produce the resulting shape.
 
-The 'Mesh' representation of an element does account for voids, such that no additional operations are required.
+The 'Reference' representation of an element does account for voids at export, such that no additional operations are required at import.
 
 ```
 concept {
@@ -13,8 +13,8 @@ concept {
     IfcRelVoidsElement:RelatedOpeningElement -> IfcOpeningElement
     IfcOpeningElement:PredefinedType -> IfcOpeningElementTypeEnum
     IfcOpeningElement:FillsVoids -> IfcRelFillsElement:RelatedBuildingElement
-    IfcRelFillsElement:RelatedBuildingElement -> IfcDoor
-    IfcRelFillsElement:RelatedBuildingElement -> IfcWindow
+    IfcRelFillsElement:RelatedBuildingElement -> IfcElement
+
     IfcElement:HasOpenings[binding="HasOpenings"]
     IfcRelVoidsElement:RelatedOpeningElement[binding="RelatedOpeningElement"]
     IfcOpeningElement:PredefinedType[binding="OpeningElementType"]

--- a/docs/templates/Object Composition/Element Voiding/Element Openings/README.md
+++ b/docs/templates/Object Composition/Element Voiding/Element Openings/README.md
@@ -9,13 +9,13 @@ The 'Reference' representation of an element does account for voids at export, s
 
 ```
 concept {
-    IfcElement:HasOpenings -> IfcRelVoidsElement:RelatingBuildingElement
+    IfcElement_0:HasOpenings -> IfcRelVoidsElement:RelatingBuildingElement
     IfcRelVoidsElement:RelatedOpeningElement -> IfcOpeningElement
-    IfcOpeningElement:PredefinedType -> IfcOpeningElementTypeEnum
+IfcOpeningElement:PredefinedType -> IfcOpeningElementTypeEnum
     IfcOpeningElement:FillsVoids -> IfcRelFillsElement:RelatedBuildingElement
-    IfcRelFillsElement:RelatedBuildingElement -> IfcElement
+    IfcRelFillsElement:RelatedBuildingElement -> IfcElement_1
 
-    IfcElement:HasOpenings[binding="HasOpenings"]
+    IfcElement_1:HasOpenings[binding="HasOpenings"]
     IfcRelVoidsElement:RelatedOpeningElement[binding="RelatedOpeningElement"]
     IfcOpeningElement:PredefinedType[binding="OpeningElementType"]
     IfcOpeningElement:FillsVoids[binding="FillsVoids"]


### PR DESCRIPTION
See below for the result. I took a bit of a leap of interpretation with the table.

Edited:

![afbeelding](https://github.com/buildingSMART/IFC4.3.x-development/assets/1096535/b4315c9e-8576-4ced-8bec-636cb0bf1986)

We have the mirror template in opposite direction here https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/concepts/Object_Connectivity/Element_Filling/content.html

With very strange parametrization entities. What to do with those?

Please ignore NBN-093 when reviewing.