### PR TITLE
Small typos fixed

### DIFF
--- a/code/server.py
+++ b/code/server.py
@@ -505,7 +505,7 @@ def process_graphviz(current_entity, md):
 
 
 def create_entity_definition(e, bindings, ports):
-    # unique name (postfix for multiple occurences, can have template bindings)
+    # unique name (postfix for multiple occurrences, can have template bindings)
     EE = e
 
     # schema name, updated when traversing supertypes

--- a/code/xmi_document.py
+++ b/code/xmi_document.py
@@ -487,7 +487,7 @@ class xmi_document:
                         
                     # There are several kinds of pset and qset association mechanisms:
                     # 
-                    # - occurence driven: only applicable to IfcObject subtypes
+                    # - occurrence driven: only applicable to IfcObject subtypes
                     # - type driven: only applicable to IfcTypeObject subtypes
                     # - type driven override: applicable to both IfcObject and IfcTypeObject
                     #                         where the former can override the latter
@@ -857,10 +857,10 @@ class xmi_document:
                 attribute_dict = dict(attributes)
                 
                 itm_supertype_names = set(self.supertypes(c.idref))
-                is_occurence=itm_supertype_names & {"IfcElement", "IfcSystem", "IfcSpatialStructureElement"}
+                is_occurrence=itm_supertype_names & {"IfcElement", "IfcSystem", "IfcSpatialStructureElement"}
                 is_type = "IfcElementType" in itm_supertype_names
                 
-                if is_type or is_occurence:
+                if is_type or is_occurrence:
                     if "PredefinedType" in attribute_dict:
                         type_attr = attribute_dict["PredefinedType"]
                         type_name = type_attr.split(" ")[-1]
@@ -870,7 +870,7 @@ class xmi_document:
                         rule = clause_1 + "(PredefinedType <> %(type_name)s.USERDEFINED) OR\n ((PredefinedType = %(type_name)s.USERDEFINED) AND EXISTS (SELF\\%(attr)s))" % locals()
                         constraints_by_type["EXPRESS_WHERE"].append(("CorrectPredefinedType", rule))
 
-                if is_occurence:
+                if is_occurrence:
                     if c.name + "Type" in [x.name for x in self.xmi.by_tag_and_type["packagedElement"]["uml:Class"]]:
                         ty_def = [x for x in self.xmi.by_tag_and_type["packagedElement"]["uml:Class"] if x.name == c.name + "Type"][0]
                         ty_attr_names = [attr.name for attr in ty_def/"ownedAttribute"]

--- a/docs/schemas/shared/IfcSharedBldgElements/Entities/IfcDoor.md
+++ b/docs/schemas/shared/IfcSharedBldgElements/Entities/IfcDoor.md
@@ -13,7 +13,7 @@ There are two main representations for door occurrences:
 
 In addition, an _IfcDoor_ may commonly include a 'FootPrint' representation defining the 2D shape of the door and its swing.
 
-The parameters of a door are defined by both the _IfcDoor_ occurence and its _IfcDoorType_. The _IfcDoor_ specifies:
+The parameters of a door are defined by both the _IfcDoor_ occurrence and its _IfcDoorType_. The _IfcDoor_ specifies:
 
  * the door width and height
  * the door opening direction (by the positive y-axis of the _ObjectPlacement_)

--- a/docs/schemas/shared/IfcSharedFacilitiesElements/PropertySets/Pset_ConstructionOccurence.md
+++ b/docs/schemas/shared/IfcSharedFacilitiesElements/PropertySets/Pset_ConstructionOccurence.md
@@ -1,3 +1,3 @@
 # Pset_ConstructionOccurence
 
-Property set for construction occurence.
+Property set for construction occurrence.

--- a/reference_schemas/psd/Pset_ReferentCommon.xml
+++ b/reference_schemas/psd/Pset_ReferentCommon.xml
@@ -11,7 +11,7 @@
   <PropertyDefs>
     <PropertyDef ifdguid="108b47e283b7482aae7240f327123803">
       <Name>NameFormat</Name>
-      <Definition>Specifies a reference to or description of the formatting or encoding of the Name attribute of the _IfcReferent_ occurence.</Definition>
+      <Definition>Specifies a reference to or description of the formatting or encoding of the Name attribute of the _IfcReferent_ occurrence.</Definition>
       <PropertyType>
         <TypePropertySingleValue>
           <DataType type="IfcLabel" />


### PR DESCRIPTION
I've fixed the easy ones to fix. 

There are still a couple of similar typos but since they are in pset names / IfcEvent property name they are not that easy to change.
https://github.com/buildingSMART/IFC4.3.x-development/blob/master/docs/schemas/shared/IfcSharedFacilitiesElements/PropertySets/Pset_ConstructionOccurence.md
https://github.com/buildingSMART/IFC4.3.x-development/blob/master/docs/schemas/domain/IfcRailDomain/PropertySets/Pset_CableSegmentOccurenceFiberSegment.md
https://github.com/buildingSMART/IFC4.3.x-development/blob/master/docs/schemas/core/IfcProcessExtension/Entities/IfcEvent.md
https://github.com/buildingSMART/IFC4.3.x-development/blob/master/code/IFC4_conf.xml