### PR TITLE
FR-547 MODULO additions

### DIFF
--- a/docs/schemas/resource/IfcCostResource/Entities/IfcAppliedValue.md
+++ b/docs/schemas/resource/IfcCostResource/Entities/IfcAppliedValue.md
@@ -15,6 +15,10 @@ Applied values may be referenced from a document (such as a price list). The rel
 { .change-ifc2x4}
 > IFC4 CHANGE  Entity made non-abstract to support general formula expressions of constraints, data type of date-based attributes changed into _IfcDate_, _ValueType_ and _Condition_ promoted from _IfcCostValue_, _Components_ and _ArithmeticOperator_ attributes added to replace _IfcAppliedValueRelationship_ for more efficient encoding and reference tracking.
 
+## Informal propositions
+
+1. When the *ArithmeticOperator* equals `MODULO``, the list of *Components* shall contain exactly two values, which shall be positive integers.
+
 ## Attributes
 
 ### Name

--- a/docs/schemas/resource/IfcCostResource/Types/IfcArithmeticOperatorEnum.md
+++ b/docs/schemas/resource/IfcCostResource/Types/IfcArithmeticOperatorEnum.md
@@ -17,3 +17,6 @@ Multiply
 
 ### SUBTRACT
 Subtract
+
+### MODULO
+Modulo. The remainder of division given two positive integer numbers.


### PR DESCRIPTION
As brought up by Pierre-Francois, it's probably useful to constrain the usage of the modulo operator as

> this operator is implemented differently by programming languages when it is used with negative integers or reals.

https://en.wikipedia.org/wiki/Modulo

> This point is illustrated in ISO/IEC 14882:2020 (C++) as the distinction between:
> 
>     std::fmod(10, 3.5) -> 3.0 as 10 - 2 × 3.5
>     std::remainder(10, 3.5) -> -0.5 as 10 - 3 × 3.5
>
> I am personally left a bit confused though as I could imagine this same distinction with integers:
>
>     11 % 4 -> 3 as 11 - 2 * 4
>     11 % 4 -> -1 as 11 - 3 * 4

If this turns out to be too restrictive we can stipulate the behaviour for other operands (following e.g std::fmod() or std::remainder()) in collaboration with vendors. But for now it's probably best to stay on the safe side to prevent implementation differences.

