### PR TITLE
Update TileLength.md

### DIFF
--- a/docs/properties/t/TileLength.md
+++ b/docs/properties/t/TileLength.md
@@ -1,4 +1,4 @@
 TileLength
 ==========
 
-Length of ceiling tiles. The size information is provided in addition to the shape representation and the geometric parameters used within. In cases of inconsistency between the geometric parameters and the size properties, provided in the attached property set, the geometric parameters take precedence.
+Length of tiles. The size information is provided in addition to the shape representation and the geometric parameters used within. In cases of inconsistency between the geometric parameters and the size properties, provided in the attached property set, the geometric parameters take precedence.


### PR DESCRIPTION
TileLength is now applicable to IfcCovering and IfcPavement. Furthermore, TileLength als applies to flooring and Cladding, not just ceiling.