### PR TITLE
Update IfcVoidingFeature.md

### DIFF
--- a/docs/schemas/domain/IfcStructuralElementsDomain/Entities/IfcVoidingFeature.md
+++ b/docs/schemas/domain/IfcStructuralElementsDomain/Entities/IfcVoidingFeature.md
@@ -46,6 +46,13 @@ The local placement for IfcVoidingFeature is defined in its supertype IfcProduct
 
 ### Property Sets for Objects
 
+### Quantity Sets
+
+
+
+### Reference Geometry
+
+Since there are no Boolean operations, either as _IfcBooleanResult_ or implicitly by _IfcRelVoidsElement_, the geometry of the _IfcOpeningElement_ shall not be used to subtract the opening from the 'Body' shape representation of the voided element.
 
 
 ### Reference SweptSolid PolyCurve Geometry


### PR DESCRIPTION
The number of holes in buildings can exceed the number of openings. I suggest adding the use of Reference Geometry concept for IfcVoidingFeature in the same way as IfcOpeningElement.  An IFC file with Reference Geometry for IfcVoidingFeature will make the work of viewers easier.

I also suggest using Quantity Sets concept for IfcVoidingFeature. Holes reduce the weight of building structures while increasing the surface area of the structure. It will be useful to get the design characteristics of holes for consideration in the building model.

I note that these changes will be useful in IFC4_ADD2_TC1 - 4.0.2.1