### PR TITLE
Changes CoefficientsX to CoefficientsY

### DIFF
--- a/docs/templates/Partial Templates/Geometry/Curve Segment Geometry/Cubic Transition Segment/README.md
+++ b/docs/templates/Partial Templates/Geometry/Curve Segment Geometry/Cubic Transition Segment/README.md
@@ -3,7 +3,7 @@ Cubic Transition Segment
 
 The cubic transition segment is modelled with _IfcPolynomialCurve_ with certain restrictions. The size of the attribute _CoefficientsY_ is restricted to 4. The cubic term is on position 4. In general, the _CoefficientsX_ size would be restricted to 2 and values specified as [0, 1]. This produces the following result:
 
-y = CoefficientsX[3]*x³, where other values in _CoefficientsY_ are 0.
+y = CoefficientsY[3]*x³, where other values in _CoefficientsY_ are 0.
 
 ```
 concept {


### PR DESCRIPTION
CoefficientsX are limited to CoefficientsX[0] and CoefficientsX[1].

The correct coefficient for y = a*x^3 is CoefficientsY[3]