### PR TITLE
Clarifies when zero-length segments are required in the geometric definition

### DIFF
--- a/docs/templates/Object Composition/Nesting/Alignment Layouts/Alignment Layout - Horizontal, Vertical and Cant/README.md
+++ b/docs/templates/Object Composition/Nesting/Alignment Layouts/Alignment Layout - Horizontal, Vertical and Cant/README.md
@@ -6,7 +6,7 @@ Nesting relationships between _IfcAlignment_ and the three layouts, with respect
 When defining the list of segments for the business logic (i.e., _IfcAlignmentHorizontalSegment_, _IfcAlignmentVerticalSegment_, _IfcAlignmentCantSegment_):
 
 1. A **zero-length segment** shall be added, at the end of the list of segments for _IfcAlignmentSegment.DesignParameters_.
-2. If the geometry definition is also present, then each of the zero-length segments shall have a _IfcCurveSegment_ counterpart - of length zero.
+2. If the geometry definition is also present, and it is not IfcOffsetCurveByDistances, IfcPolyline or IfcIndexedPolyCurve, then each of the zero-length segments shall have a _IfcCurveSegment_ counterpart - of length zero.
 
 ```
 concept {


### PR DESCRIPTION
The requirement for zero length segment of type IfcCurveSegment is impossible to satisfy if the geometric representation is not IfcCompositeCurve or one if its derived types