### PR TITLE
Amend README.md

### DIFF
--- a/docs/schemas/resource/README.md
+++ b/docs/schemas/resource/README.md
@@ -1,7 +1,7 @@
 Resource definition data schemas
 ========================
 
-The resource definition data schemas consist of supporting data structures as shown highlighted in blue. Entities and types defined in this layer can be referenced by all entities in the layers below.
+The resource definition data schemas consist of supporting data structures as shown below. Entities and types defined in this layer can be referenced by all entities in the layers below.
 
 Unlike entities in other layers, resource definition data structures cannot exist independently, but can only exist if referenced (directly or indirectly) by one or more entities deriving from IfcRoot. As resource definitions do not have a concept of identity (such as a GUID), multiple objects referencing the same instance of a resource entity does not imply a relationship. For example, two polylines (IfcPolyline) sharing the same instance for a point (IfcCartesianPoint), and two polylines using different instances for identical points (such as both having cordinates 0,0,0) are semantically equivalent. It is recommended (but not required) for applications to minimize file size by sharing identical resource definition instances where possible.
 


### PR DESCRIPTION
The previous README was showing as the follows which are obviously wrong. Changed as per IFC4.2.

Resource Type Assignment

Resource types may have assignments indicating re-usable product types for which occurrences may be sourced by occurrences of the resource type. An example of such assignment is a particular crane model that may be used for a crane equipment resource used for erecting steel.