### PR TITLE
fix: correct ISO standard reference in Pset_Risk description

### DIFF
--- a/docs/schemas/shared/IfcSharedFacilitiesElements/PropertySets/Pset_Risk.md
+++ b/docs/schemas/shared/IfcSharedFacilitiesElements/PropertySets/Pset_Risk.md
@@ -1,6 +1,6 @@
 # Pset_Risk
 
-An indication of exposure to mischance, peril, menace, hazard or loss. Documentation of a potential hazard, likilihood and consequence aligned with AS/NZS 4360 and BS PAS 1192-6:2017, which can be assigned to or associated with a product, activity and/or location. Alternatively it may be assigned to an ISO 3864 annotation symbol.
+An indication of exposure to mischance, peril, menace, hazard or loss. Documentation of a potential hazard, likilihood and consequence aligned with AS/NZS 4360 and BS PAS 1192-6:2017, which can be assigned to or associated with a product, activity and/or location. Alternatively it may be assigned to an ISO 7010 annotation symbol.
 <!-- end of short definition -->
 
 > HISTORY Extended in IFC2x3, Revised IFC4x3


### PR DESCRIPTION
Change ISO 3864 to ISO 7010 for annotation symbol reference. ISO 3864 defines safety sign design principles (shapes, colours, layouts), while ISO 7010 is the registered catalogue of specific safety sign symbols. Since the context refers to a specific annotation symbol, ISO 7010 is the appropriate standard.