### PR TITLE
Move short definition text before marker on IfcProcedureType and IfcEventType

### DIFF
--- a/docs/schemas/core/IfcProcessExtension/Entities/IfcEventType.md
+++ b/docs/schemas/core/IfcProcessExtension/Entities/IfcEventType.md
@@ -1,11 +1,9 @@
 # IfcEventType
 
->
+An _IfcEventType_ provides for all forms of types of event that may be specified.
 <!-- end of short definition -->
 
- HISTORY New entity in IFC4
-
-An _IfcEventType_ provides for all forms of types of event that may be specified.
+> HISTORY New entity in IFC4
 
 Usage of _IfcEventType_ defines the parameters for one or more occurrences of _IfcEvent_. Parameters may be specified through property sets that may be enumerated in the _IfcEventTypeEnum_ data type or through explicit attributes of _IfcEvent_. Event occurrences (_IfcEvent_ entities) are linked to the event type through the _IfcRelDefinesByType_ relationship.
 

--- a/docs/schemas/core/IfcProcessExtension/Entities/IfcProcedureType.md
+++ b/docs/schemas/core/IfcProcessExtension/Entities/IfcProcedureType.md
@@ -1,11 +1,9 @@
 # IfcProcedureType
 
->
+An _IfcProcedureType_ provides for all forms of types of procedure that may be specified.
 <!-- end of short definition -->
 
- HISTORY New entity in IFC4
-
-An _IfcProcedureType_ provides for all forms of types of procedure that may be specified.
+> HISTORY New entity in IFC4
 
 Usage of _IfcProcedureType_ defines the parameters for one or more occurrences of _IfcProcedure_. Parameters may be specified through property sets that may be enumerated in the _IfcProcedureTypeEnum_ data type or through explicit attributes of _IfcProcedure_. Procedure occurrences (_IfcProcedure_ entities) are linked to the procedure type through the _IfcRelDefinesByType_ relationship.
 


### PR DESCRIPTION
Moved the short definition marker on both IfcProcedureType and IfcEventType pages and placed the `HISTORY` note inside a blockquote so it renders correctly.

Previously, an empty blockquote was rendering as a blank orange box and the history text was appearing outside the quote. Formatting now matches other pages such as IfcTaskType.