### PR TITLE
Prepare for Eclipse XML syntax

### DIFF
--- a/code/generators/util/xmi.py
+++ b/code/generators/util/xmi.py
@@ -26,8 +26,8 @@ class base(object):
     
     def traverse(self):
         if getattr(self.xml, 'tagName', '') == "packageImport":
-            # Legacy EA form:        <packageImport importedPackage="file.uml#id"/>
-            # Papyrus-canonical form: <packageImport><importedPackage href="file.uml#id"/></packageImport>
+            # EA       <packageImport importedPackage="file.uml#id"/>
+            # Java form: <packageImport><importedPackage href="file.uml#id"/></packageImport>
             ip = self.attributes().get('importedPackage')
             if ip is None:
                 try:

--- a/code/generators/util/xmi.py
+++ b/code/generators/util/xmi.py
@@ -26,15 +26,8 @@ class base(object):
     
     def traverse(self):
         if getattr(self.xml, 'tagName', '') == "packageImport":
-            # EA       <packageImport importedPackage="file.uml#id"/>
-            # Java form: <packageImport><importedPackage href="file.uml#id"/></packageImport>
-            ip = self.attributes().get('importedPackage')
-            if ip is None:
-                try:
-                    ip = (self | 'importedPackage').href
-                except ValueError:
-                    ip = None
-            if ip and '#' in ip:
+            ip = self.resolve('importedPackage', keep_prefix=True)
+            if '#' in ip:
                 fn, hash = ip.split('#')
                 if dc := self.doc.imports.get(fn):
                     pass
@@ -62,11 +55,12 @@ class node(base):
     def tags(self):    
         return dict(map(lambda t: (t.name, t.value), self/"tag"))
     
-    def resolve(self, k):
+    def resolve(self, k, keep_prefix=False):
         v = self.attributes().get(k)
         if v is not None:
             return v
-        return (self | k).href.split('#')[1]
+        href = (self | k).href
+        return href if keep_prefix else href.split('#')[1]
 
     def attributes(self):
         return dict((k, getattr(self, k)) for k in self.xml.attributes.keys())

--- a/code/generators/util/xmi.py
+++ b/code/generators/util/xmi.py
@@ -25,13 +25,22 @@ class base(object):
         return li[0]
     
     def traverse(self):
-        if getattr(self.xml, 'tagName', '') == "packageImport" and '#' in self.resolve('importedPackage'):
-            fn, hash = self.resolve('importedPackage').split('#')
-            if dc := self.doc.imports.get(fn):
-                pass
-            else:
-                dc = self.doc.imports[fn] = doc(str(Path(self.doc.filename).parent / fn))
-            self = dc.by_id[hash]
+        if getattr(self.xml, 'tagName', '') == "packageImport":
+            # Legacy EA form:        <packageImport importedPackage="file.uml#id"/>
+            # Papyrus-canonical form: <packageImport><importedPackage href="file.uml#id"/></packageImport>
+            ip = self.attributes().get('importedPackage')
+            if ip is None:
+                try:
+                    ip = (self | 'importedPackage').href
+                except ValueError:
+                    ip = None
+            if ip and '#' in ip:
+                fn, hash = ip.split('#')
+                if dc := self.doc.imports.get(fn):
+                    pass
+                else:
+                    dc = self.doc.imports[fn] = doc(str(Path(self.doc.filename).parent / fn))
+                self = dc.by_id[hash]
         yield self
         for c in self.children:
             yield from c.traverse()

--- a/code/generators/util/xmi_document.py
+++ b/code/generators/util/xmi_document.py
@@ -454,7 +454,7 @@ class xmi_document:
                     ty = self.xmi.by_id[(attr.resolve("type"))]
                     
                     if c.name.startswith("Pset"):
-                        bounds = ((attr|"lowerValue").value, (attr|"upperValue").value)
+                        bounds = ((attr|"lowerValue").value or "0", (attr|"upperValue").value)
                         prop_args = {"Type": re.split(r'_\w\[', ty.name)[0]}
 
                         allowed_reference_types = {"IfcAddress", "IfcAppliedValue", "IfcExternalReference", "IfcMaterialDefinition", "IfcOrganization", "IfcPerson", "IfcPersonAndOrganization", "IfcTable", "IfcTimeSeries"}
@@ -570,7 +570,7 @@ class xmi_document:
                     else:
                         name, *aggr = a.name.split('_')
                         parts = []
-                        if (a|'lowerValue').value == "0":
+                        if ((a|'lowerValue').value or "0") == "0":
                             parts.append("OPTIONAL")
                         for ag in aggr:
                             parts.extend(format_aggr(ag))

--- a/code/generators/util/xmi_document.py
+++ b/code/generators/util/xmi_document.py
@@ -454,7 +454,7 @@ class xmi_document:
                     ty = self.xmi.by_id[(attr.resolve("type"))]
                     
                     if c.name.startswith("Pset"):
-                        bounds = ((attr|"lowerValue").value or "0", (attr|"upperValue").value)
+                        bounds = ((attr|"lowerValue").value or "0", (attr|"upperValue").value or "1")
                         prop_args = {"Type": re.split(r'_\w\[', ty.name)[0]}
 
                         allowed_reference_types = {"IfcAddress", "IfcAppliedValue", "IfcExternalReference", "IfcMaterialDefinition", "IfcOrganization", "IfcPerson", "IfcPersonAndOrganization", "IfcTable", "IfcTimeSeries"}

--- a/code/xmi.py
+++ b/code/xmi.py
@@ -26,8 +26,8 @@ class base(object):
     
     def traverse(self):
         if getattr(self.xml, 'tagName', '') == "packageImport":
-            # Legacy EA form:        <packageImport importedPackage="file.uml#id"/>
-            # Papyrus-canonical form: <packageImport><importedPackage href="file.uml#id"/></packageImport>
+            # EA -form        <packageImport importedPackage="file.uml#id"/>
+            # java: <packageImport><importedPackage href="file.uml#id"/></packageImport>
             ip = self.attributes().get('importedPackage')
             if ip is None:
                 try:

--- a/code/xmi.py
+++ b/code/xmi.py
@@ -26,15 +26,8 @@ class base(object):
     
     def traverse(self):
         if getattr(self.xml, 'tagName', '') == "packageImport":
-            # EA -form        <packageImport importedPackage="file.uml#id"/>
-            # java: <packageImport><importedPackage href="file.uml#id"/></packageImport>
-            ip = self.attributes().get('importedPackage')
-            if ip is None:
-                try:
-                    ip = (self | 'importedPackage').href
-                except ValueError:
-                    ip = None
-            if ip and '#' in ip:
+            ip = self.resolve('importedPackage', keep_prefix=True)
+            if '#' in ip:
                 fn, hash = ip.split('#')
                 if dc := self.doc.imports.get(fn):
                     pass
@@ -62,11 +55,12 @@ class node(base):
     def tags(self):    
         return dict(map(lambda t: (t.name, t.value), self/"tag"))
     
-    def resolve(self, k):
+    def resolve(self, k, keep_prefix=False):
         v = self.attributes().get(k)
         if v is not None:
             return v
-        return (self | k).href.split('#')[1]
+        href = (self | k).href
+        return href if keep_prefix else href.split('#')[1]
 
     def attributes(self):
         return dict((k, getattr(self, k)) for k in self.xml.attributes.keys())

--- a/code/xmi.py
+++ b/code/xmi.py
@@ -25,13 +25,22 @@ class base(object):
         return li[0]
     
     def traverse(self):
-        if getattr(self.xml, 'tagName', '') == "packageImport" and '#' in self.resolve('importedPackage'):
-            fn, hash = self.resolve('importedPackage').split('#')
-            if dc := self.doc.imports.get(fn):
-                pass
-            else:
-                dc = self.doc.imports[fn] = doc(str(Path(self.doc.filename).parent / fn))
-            self = dc.by_id[hash]
+        if getattr(self.xml, 'tagName', '') == "packageImport":
+            # Legacy EA form:        <packageImport importedPackage="file.uml#id"/>
+            # Papyrus-canonical form: <packageImport><importedPackage href="file.uml#id"/></packageImport>
+            ip = self.attributes().get('importedPackage')
+            if ip is None:
+                try:
+                    ip = (self | 'importedPackage').href
+                except ValueError:
+                    ip = None
+            if ip and '#' in ip:
+                fn, hash = ip.split('#')
+                if dc := self.doc.imports.get(fn):
+                    pass
+                else:
+                    dc = self.doc.imports[fn] = doc(str(Path(self.doc.filename).parent / fn))
+                self = dc.by_id[hash]
         yield self
         for c in self.children:
             yield from c.traverse()

--- a/code/xmi_document.py
+++ b/code/xmi_document.py
@@ -454,7 +454,7 @@ class xmi_document:
                     ty = self.xmi.by_id[(attr.resolve("type"))]
                     
                     if c.name.startswith("Pset"):
-                        bounds = ((attr|"lowerValue").value, (attr|"upperValue").value)
+                        bounds = ((attr|"lowerValue").value or "0", (attr|"upperValue").value)
                         prop_args = {"Type": re.split(r'_\w\[', ty.name)[0]}
 
                         allowed_reference_types = {"IfcAddress", "IfcAppliedValue", "IfcExternalReference", "IfcMaterialDefinition", "IfcOrganization", "IfcPerson", "IfcPersonAndOrganization", "IfcTable", "IfcTimeSeries"}
@@ -570,7 +570,7 @@ class xmi_document:
                     else:
                         name, *aggr = a.name.split('_')
                         parts = []
-                        if (a|'lowerValue').value == "0":
+                        if ((a|'lowerValue').value or "0") == "0":
                             parts.append("OPTIONAL")
                         for ag in aggr:
                             parts.extend(format_aggr(ag))

--- a/code/xmi_document.py
+++ b/code/xmi_document.py
@@ -454,7 +454,7 @@ class xmi_document:
                     ty = self.xmi.by_id[(attr.resolve("type"))]
                     
                     if c.name.startswith("Pset"):
-                        bounds = ((attr|"lowerValue").value or "0", (attr|"upperValue").value)
+                        bounds = ((attr|"lowerValue").value or "0", (attr|"upperValue").value or "1")
                         prop_args = {"Type": re.split(r'_\w\[', ty.name)[0]}
 
                         allowed_reference_types = {"IfcAddress", "IfcAppliedValue", "IfcExternalReference", "IfcMaterialDefinition", "IfcOrganization", "IfcPerson", "IfcPersonAndOrganization", "IfcTable", "IfcTimeSeries"}


### PR DESCRIPTION
While running 
`python -m generators.express schemas/ifc4x3_add2.uml -o /tmp/out.exp`

I run into the following error:

The old shape: 

`<packageImport importedPackage="IfcKernel.uml#pk_IfcKernel"/>`

new Eclipse xml shape: 

```
<packageImport>
  <importedPackage href="IfcKernel.uml#pk_IfcKernel"/>
</packageImport>
```

Will add other findings to this PR 

cc @aothms 