### PR TITLE
[TM24] Linear zone and typical sections

### DIFF
--- a/docs/properties/a/AreHolesGrouted.md
+++ b/docs/properties/a/AreHolesGrouted.md
@@ -1,0 +1,4 @@
+AreHolesGrouted
+===============
+
+Specifies whether holes are grouted after insertion of pipes/bars.

--- a/docs/properties/a/AsbestosPotential.md
+++ b/docs/properties/a/AsbestosPotential.md
@@ -1,0 +1,4 @@
+AsbestosPotential
+=================
+
+Description or rating of the potential presence of asbestos in the ground.

--- a/docs/properties/b/BoreholeLengthPlanned.md
+++ b/docs/properties/b/BoreholeLengthPlanned.md
@@ -1,0 +1,4 @@
+BoreholeLengthPlanned
+=====================
+
+The planned length of a borehole e.g. in a site investigation program, in metres, as determined by the data provider.

--- a/docs/properties/b/BoreholeOverlap.md
+++ b/docs/properties/b/BoreholeOverlap.md
@@ -1,0 +1,4 @@
+BoreholeOverlap
+===============
+
+Overlap of staggered boreholes.

--- a/docs/properties/b/Boulders.md
+++ b/docs/properties/b/Boulders.md
@@ -1,0 +1,4 @@
+Boulders
+========
+
+Description of expected or observed boulders features.

--- a/docs/properties/c/CloggingPotential.md
+++ b/docs/properties/c/CloggingPotential.md
@@ -1,0 +1,4 @@
+CloggingPotential
+=================
+
+Description or rating of the potential for clogging equipment in sticky ground.

--- a/docs/properties/c/Contamination.md
+++ b/docs/properties/c/Contamination.md
@@ -1,0 +1,4 @@
+Contamination
+=============
+
+Expected anthropogenic contaminations.

--- a/docs/properties/d/DrillingDiameter.md
+++ b/docs/properties/d/DrillingDiameter.md
@@ -1,0 +1,4 @@
+DrillingDiameter
+================
+
+Drilled diameter.

--- a/docs/properties/d/DrillingMethod.md
+++ b/docs/properties/d/DrillingMethod.md
@@ -1,0 +1,4 @@
+DrillingMethod
+==============
+
+Type of drilling method used.

--- a/docs/properties/d/DumpCategory.md
+++ b/docs/properties/d/DumpCategory.md
@@ -1,0 +1,4 @@
+DumpCategory
+============
+
+Project-related category for re-use and storage of the excavated material.

--- a/docs/properties/g/GasConcentration.md
+++ b/docs/properties/g/GasConcentration.md
@@ -1,0 +1,4 @@
+GasConcentration
+================
+
+Expected concentration of gas to be encountered during excavation.

--- a/docs/properties/g/GroundTemperature.md
+++ b/docs/properties/g/GroundTemperature.md
@@ -1,0 +1,4 @@
+GroundTemperature
+=================
+
+Ground temperature expected in the subject section.

--- a/docs/properties/g/GroundwaterAgressiveness.md
+++ b/docs/properties/g/GroundwaterAgressiveness.md
@@ -1,0 +1,4 @@
+GroundwaterAgressiveness
+========================
+
+Rating of the agressiveness e.g. towards concrete.

--- a/docs/properties/g/GroundwaterDesignPressure.md
+++ b/docs/properties/g/GroundwaterDesignPressure.md
@@ -1,0 +1,4 @@
+GroundwaterDesignPressure
+=========================
+
+Groundwater pressure to be considered in the design.

--- a/docs/properties/g/GroundwaterTemperature.md
+++ b/docs/properties/g/GroundwaterTemperature.md
@@ -1,0 +1,4 @@
+GroundwaterTemperature
+======================
+
+Groundwater temperature observed at specific location or expected in the subject section.

--- a/docs/properties/g/GroutingType.md
+++ b/docs/properties/g/GroutingType.md
@@ -1,0 +1,4 @@
+GroutingType
+============
+
+Type of grouting used.

--- a/docs/properties/h/HeavyMetalsPotential.md
+++ b/docs/properties/h/HeavyMetalsPotential.md
@@ -1,0 +1,4 @@
+HeavyMetalsPotential
+====================
+
+Description or rating of the potential presence of heavy metals in the ground.

--- a/docs/properties/i/InSituStress.md
+++ b/docs/properties/i/InSituStress.md
@@ -1,0 +1,4 @@
+InSituStress
+============
+
+Anisotropic stress regime, with direction and magnitude of principal stresses.

--- a/docs/properties/i/IsBoreholeCased.md
+++ b/docs/properties/i/IsBoreholeCased.md
@@ -1,0 +1,4 @@
+IsBoreholeCased
+===============
+
+Specifies whether the boreholes are cased or not.

--- a/docs/properties/k/Karst.md
+++ b/docs/properties/k/Karst.md
@@ -1,0 +1,4 @@
+Karst
+=====
+
+Description of expected or observed karst features.

--- a/docs/properties/l/LongitudinalSpacing.md
+++ b/docs/properties/l/LongitudinalSpacing.md
@@ -1,0 +1,4 @@
+LongitudinalSpacing
+===================
+
+Longitudinal spacing between elements.

--- a/docs/properties/m/MaxGroundwaterInflow.md
+++ b/docs/properties/m/MaxGroundwaterInflow.md
@@ -1,0 +1,4 @@
+MaxGroundwaterInflow
+====================
+
+Groundwater inflow measured or expected durng a certain time span.

--- a/docs/properties/n/NumberOfBolts.md
+++ b/docs/properties/n/NumberOfBolts.md
@@ -1,0 +1,4 @@
+NumberOfBolts
+=============
+
+Number of bolts in the bolted area.

--- a/docs/properties/o/Overburden.md
+++ b/docs/properties/o/Overburden.md
@@ -1,0 +1,4 @@
+Overburden
+==========
+
+Range of overburden (distance from tunnel to ground surface) in the subject section.

--- a/docs/properties/p/PlateType.md
+++ b/docs/properties/p/PlateType.md
@@ -1,0 +1,4 @@
+PlateType
+=========
+
+Type of bolt plate used.

--- a/docs/properties/p/PreSupportLocation.md
+++ b/docs/properties/p/PreSupportLocation.md
@@ -1,0 +1,4 @@
+PreSupportLocation
+==================
+
+Specifies whether the pre-support is in face or around circumference.

--- a/docs/properties/p/PreSupportType.md
+++ b/docs/properties/p/PreSupportType.md
@@ -1,0 +1,4 @@
+PreSupportType
+==============
+
+Specifies the type of pre-support applied.

--- a/docs/properties/r/RadialSpacing.md
+++ b/docs/properties/r/RadialSpacing.md
@@ -1,0 +1,4 @@
+RadialSpacing
+=============
+
+Radial spacing between elements.

--- a/docs/properties/s/Swelling.md
+++ b/docs/properties/s/Swelling.md
@@ -1,0 +1,4 @@
+Swelling
+========
+
+Expected swelling behaviour.

--- a/docs/properties/u/UsefulLength.md
+++ b/docs/properties/u/UsefulLength.md
@@ -1,0 +1,4 @@
+UsefulLength
+============
+
+Length that can be used, generally length less overlap.

--- a/docs/properties/u/UserDefinedGroutingType.md
+++ b/docs/properties/u/UserDefinedGroutingType.md
@@ -1,0 +1,4 @@
+UserDefinedGroutingType
+=======================
+
+A user defined grouting type for when _GroutingType_ is set to USERDEFINED.

--- a/docs/properties/u/UserDefinedPreSupportLocation.md
+++ b/docs/properties/u/UserDefinedPreSupportLocation.md
@@ -1,0 +1,4 @@
+UserDefinedPreSupportLocation
+=============================
+
+Specifies a user defined pre-support location. Used when PreSupportLocation is set to USERDEFINED.

--- a/docs/properties/u/UserDefinedPreSupportType.md
+++ b/docs/properties/u/UserDefinedPreSupportType.md
@@ -1,0 +1,4 @@
+UserDefinedPreSupportType
+=========================
+
+Specifies a user defined type of pre-support applied. Used when PreSupporttype is set to USERDEFINED.

--- a/docs/schemas/core/IfcProductExtension/Entities/IfcLinearZone.md
+++ b/docs/schemas/core/IfcProductExtension/Entities/IfcLinearZone.md
@@ -1,0 +1,5 @@
+# IfcLinearZone
+
+A potentially overlapping linear element that represents a sub section (from-to) of an IfcLinearPositioningElement (IfcAlignment) and as such typically carry properties (e.g. design properties) that varies along the length of the IfcLinearPositioningElement.
+<!-- end of short definition -->
+

--- a/docs/schemas/domain/IfcTunnelDomain/Entities/IfcTunnelTypicalSection.md
+++ b/docs/schemas/domain/IfcTunnelDomain/Entities/IfcTunnelTypicalSection.md
@@ -1,0 +1,16 @@
+# IfcTunnelTypicalSection
+
+Interval along the alignment/tunnel with similar conditions.
+<!-- end of short definition -->
+
+## Attributes
+
+### PredefinedType
+Predefined generic type for a tunnel typical section that is specified in an enumeration. There may be a property set given specifically for the predefined types.
+> NOTE  The _PredefinedType_ shall only be used, if no _IfcTunnelTypicalSectionType_ is assigned, providing its own _IfcTunnelTypicalSectionType.PredefinedType_.
+
+## Formal Propositions
+
+### HasObjectType
+<!-- FILL IN: prose explaining the rule. EXPRESS body: `(PredefinedType <> IfcTunnelTypicalSectionTypeEnum.USERDEFINED) OR EXISTS(SELF\IfcObject.ObjectType)` -->
+

--- a/docs/schemas/domain/IfcTunnelDomain/Types/IfcTunnelTypicalSectionTypeEnum.md
+++ b/docs/schemas/domain/IfcTunnelDomain/Types/IfcTunnelTypicalSectionTypeEnum.md
@@ -1,0 +1,22 @@
+# IfcTunnelTypicalSectionTypeEnum
+
+This enumeration defines the different predefined types of typical tunnel sections that can specify an _IfcTunnelTypicalSection_.
+<!-- end of short definition -->
+
+## Items
+
+### GEOTECH
+Interval along the alignment/built structure with similar ground conditions, as part of the GeotechSynthesis model that represents the connection between the ground model and the built structure. Includes key-properties like expected distribution of ground types (reference to GeotechUnits) and baseline-definition of expected ground conditions and potential hazards, and may also include key-information on design like excavation measures, distribution of support types etc. These properties can be provided using pre- or user-defined property sets, using IfcRelDefinesByProperties or external datasets using IfcRelAssociatesDataset.
+
+### EXCAVATIONSUPPORT
+Interval along the alignment/built structure with similar support measures. Properties can be provided using pre- or user-defined property sets, using IfcRelDefinesByProperties or external datasets using IfcRelAssociatesDataset.
+
+### RISK
+Interval along the alignment/built structure with similar risk assessment. Properties can be provided using pre- or user-defined property sets, using IfcRelDefinesByProperties or external datasets using IfcRelAssociatesDataset.
+
+### USERDEFINED
+User-defined type.
+
+### NOTDEFINED
+Undefined type.
+

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertyEnumerations/PEnum_GroutingType.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertyEnumerations/PEnum_GroutingType.md
@@ -1,0 +1,22 @@
+# PEnum_GroutingType
+<!-- end of short definition -->
+
+## Items
+
+### STDGROUTING_CEMENT
+Standard grouting cement.
+
+### MICROFINE_CEMENT
+
+### ULTRAFINE_CEMENT
+
+### CHEMICAL_COMPONENT
+
+### USERDEFINED
+User Defined
+
+### NOTKNOWN
+Value is unknown.
+
+### UNSET
+Value has not been specified.

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertyEnumerations/PEnum_GroutingType.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertyEnumerations/PEnum_GroutingType.md
@@ -3,7 +3,7 @@
 
 ## Items
 
-### STDGROUTING_CEMENT
+### STANDARD_GROUTING_CEMENT
 Standard grouting cement.
 
 ### MICROFINE_CEMENT
@@ -12,8 +12,8 @@ Standard grouting cement.
 
 ### CHEMICAL_COMPONENT
 
-### USERDEFINED
-User Defined
+### OTHER
+The type is user-defined.
 
 ### NOTKNOWN
 Value is unknown.

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertyEnumerations/PEnum_PreSupportArrangement.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertyEnumerations/PEnum_PreSupportArrangement.md
@@ -1,0 +1,10 @@
+# PEnum_PreSupportArrangement
+<!-- end of short definition -->
+
+## Items
+
+### SIMPLE
+A simple arrangement of pre-support.
+
+### STAGGERED
+A staggered arrangement of the pre-support.

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertyEnumerations/PEnum_PreSupportArrangement.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertyEnumerations/PEnum_PreSupportArrangement.md
@@ -8,3 +8,12 @@ A simple arrangement of pre-support.
 
 ### STAGGERED
 A staggered arrangement of the pre-support.
+
+### OTHER
+The type is user-defined.
+
+### NOTKNOWN
+Value is unknown.
+
+### UNSET
+Value has not been specified.

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertyEnumerations/PEnum_PreSupportLocation.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertyEnumerations/PEnum_PreSupportLocation.md
@@ -3,14 +3,17 @@
 
 ## Items
 
-### TUNNELVAULT
+### TUNNEL_VAULT
 The pre-support is around the circumference of the tunnel.
 
-### TUNNELFACE
+### TUNNEL_FACE
 The pre-support is in the tunnel face.
 
-### USERDEFINED
-User Defined
+### OTHER
+The type is user-defined.
 
-### NOTDEFINED
-Notdefined
+### NOTKNOWN
+Value is unknown.
+
+### UNSET
+Value has not been specified.

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertyEnumerations/PEnum_PreSupportLocation.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertyEnumerations/PEnum_PreSupportLocation.md
@@ -1,0 +1,16 @@
+# PEnum_PreSupportLocation
+<!-- end of short definition -->
+
+## Items
+
+### TUNNELVAULT
+The pre-support is around the circumference of the tunnel.
+
+### TUNNELFACE
+The pre-support is in the tunnel face.
+
+### USERDEFINED
+User Defined
+
+### NOTDEFINED
+Notdefined

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertyEnumerations/PEnum_PreSupportType.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertyEnumerations/PEnum_PreSupportType.md
@@ -3,10 +3,10 @@
 
 ## Items
 
-### JETGROUTED
+### JET_GROUTED
 Pre-support using jet grouting.
 
-### PIPEUMBRELLA
+### PIPE_UMBRELLA
 Pre-support using pipe umbrellas.
 
 ### FREEZING
@@ -18,8 +18,11 @@ Pre-support using forepoling.
 ### SPILING
 Pre-support using spiling.
 
-### USERDEFINED
-User Defined
+### OTHER
+The type is user-defined.
 
-### NOTDEFINED
-Notdefined
+### NOTKNOWN
+Value is unknown.
+
+### UNSET
+Value has not been specified.

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertyEnumerations/PEnum_PreSupportType.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertyEnumerations/PEnum_PreSupportType.md
@@ -1,0 +1,25 @@
+# PEnum_PreSupportType
+<!-- end of short definition -->
+
+## Items
+
+### JETGROUTED
+Pre-support using jet grouting.
+
+### PIPEUMBRELLA
+Pre-support using pipe umbrellas.
+
+### FREEZING
+Pre-support using freezing.
+
+### FOREPOLING
+Pre-support using forepoling.
+
+### SPILING
+Pre-support using spiling.
+
+### USERDEFINED
+User Defined
+
+### NOTDEFINED
+Notdefined

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeoAspects.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeoAspects.md
@@ -1,0 +1,4 @@
+# Pset_GeoAspects
+
+Description of geological aspects that are relevant for the tunnel design and execution phase.
+<!-- end of short definition -->

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_PreSupportCommon.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_PreSupportCommon.md
@@ -1,0 +1,4 @@
+# Pset_PreSupportCommon
+
+Properties describing the characteristcs of excavation pre-support measures.
+<!-- end of short definition -->

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_SupportCommon.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_SupportCommon.md
@@ -1,0 +1,4 @@
+# Pset_SupportCommon
+
+Properties describing the characteristcs of tunnel support measures.
+<!-- end of short definition -->

--- a/schemas/IfcProductExtension.uml
+++ b/schemas/IfcProductExtension.uml
@@ -63,6 +63,8 @@
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcBuiltSystemTypeEnum_SHADING" name="SHADING"/>
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcBuiltSystemTypeEnum_TRACKCIRCUIT" name="TRACKCIRCUIT"/>
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcBuiltSystemTypeEnum_TRANSPORT" name="TRANSPORT"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcBuiltSystemTypeEnum_TUNNEL_PRESUPPORT" name="TUNNEL_PRESUPPORT"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcBuiltSystemTypeEnum_TUNNEL_SUPPORT" name="TUNNEL_SUPPORT"/>
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcBuiltSystemTypeEnum_USERDEFINED" name="USERDEFINED"/>
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcBuiltSystemTypeEnum_NOTDEFINED" name="NOTDEFINED"/>
     </packagedElement>
@@ -80,6 +82,8 @@
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcElementAssemblyTypeEnum_GRID" name="GRID"/>
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcElementAssemblyTypeEnum_MAST" name="MAST"/>
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcElementAssemblyTypeEnum_PIER" name="PIER"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcElementAssemblyTypeEnum_PRESUPPORTFACE" name="PRESUPPORTFACE"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcElementAssemblyTypeEnum_PRESUPPORTVAULT" name="PRESUPPORTVAULT"/>
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcElementAssemblyTypeEnum_PYLON" name="PYLON"/>
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcElementAssemblyTypeEnum_RAIL_MECHANICAL_EQUIPMENT_ASSEMBLY" name="RAIL_MECHANICAL_EQUIPMENT_ASSEMBLY"/>
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcElementAssemblyTypeEnum_REINFORCEMENT_UNIT" name="REINFORCEMENT_UNIT"/>
@@ -1198,6 +1202,12 @@ AND
     <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcBuiltSystemTypeEnum_TRANSPORT" name="IfcBuiltSystemTypeEnum.TRANSPORT">
       <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcBuiltSystemTypeEnum_TRANSPORT_gen_IfcBuiltSystem" general="cl_IfcBuiltSystem"/>
     </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcBuiltSystemTypeEnum_TUNNEL_PRESUPPORT" name="IfcBuiltSystemTypeEnum.TUNNEL_PRESUPPORT">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcBuiltSystemTypeEnum_TUNNEL_PRESUPPORT_gen_IfcBuiltSystem" general="cl_IfcBuiltSystem"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcBuiltSystemTypeEnum_TUNNEL_SUPPORT" name="IfcBuiltSystemTypeEnum.TUNNEL_SUPPORT">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcBuiltSystemTypeEnum_TUNNEL_SUPPORT_gen_IfcBuiltSystem" general="cl_IfcBuiltSystem"/>
+    </packagedElement>
     <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcBuiltSystemTypeEnum_USERDEFINED" name="IfcBuiltSystemTypeEnum.USERDEFINED">
       <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcBuiltSystemTypeEnum_USERDEFINED_gen_IfcBuiltSystem" general="cl_IfcBuiltSystem"/>
     </packagedElement>
@@ -1255,6 +1265,14 @@ AND
     <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcElementAssemblyTypeEnum_PIER" name="IfcElementAssemblyTypeEnum.PIER">
       <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcElementAssemblyTypeEnum_PIER_gen_IfcElementAssembly" general="cl_IfcElementAssembly"/>
       <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcElementAssemblyTypeEnum_PIER_gen_IfcElementAssemblyType" general="cl_IfcElementAssemblyType"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcElementAssemblyTypeEnum_PRESUPPORTFACE" name="IfcElementAssemblyTypeEnum.PRESUPPORTFACE">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcElementAssemblyTypeEnum_PRESUPPORTFACE_gen_IfcElementAssembly" general="cl_IfcElementAssembly"/>
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcElementAssemblyTypeEnum_PRESUPPORTFACE_gen_IfcElementAssemblyType" general="cl_IfcElementAssemblyType"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcElementAssemblyTypeEnum_PRESUPPORTVAULT" name="IfcElementAssemblyTypeEnum.PRESUPPORTVAULT">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcElementAssemblyTypeEnum_PRESUPPORTVAULT_gen_IfcElementAssembly" general="cl_IfcElementAssembly"/>
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcElementAssemblyTypeEnum_PRESUPPORTVAULT_gen_IfcElementAssemblyType" general="cl_IfcElementAssemblyType"/>
     </packagedElement>
     <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcElementAssemblyTypeEnum_PYLON" name="IfcElementAssemblyTypeEnum.PYLON">
       <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcElementAssemblyTypeEnum_PYLON_gen_IfcElementAssembly" general="cl_IfcElementAssembly"/>
@@ -3843,5 +3861,8 @@ AND
     <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Qto_ProjectionElementBaseQuantities_IfcProjectionElement" client="cl_Qto_ProjectionElementBaseQuantities" supplier="cl_IfcProjectionElement"/>
     <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Qto_SiteBaseQuantities_IfcSite" client="cl_Qto_SiteBaseQuantities" supplier="cl_IfcSite"/>
     <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Qto_SpaceBaseQuantities_IfcSpace" client="cl_Qto_SpaceBaseQuantities" supplier="cl_IfcSpace"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcLinearZone" name="IfcLinearZone" isAbstract="true">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcLinearZone_gen_IfcLinearElement" general="cl_IfcLinearElement"/>
+    </packagedElement>
   </packagedElement>
 </uml:Model>

--- a/schemas/IfcSharedInfrastructureElements.uml
+++ b/schemas/IfcSharedInfrastructureElements.uml
@@ -1434,10 +1434,11 @@
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportArrangement_UNSET" name="UNSET"/>
     </packagedElement>
     <packagedElement xmi:type="uml:Enumeration" xmi:id="en_PEnum_PreSupportLocation" name="PEnum_PreSupportLocation">
-      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportLocation_TUNNELVAULT" name="TUNNELVAULT"/>
-      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportLocation_TUNNELFACE" name="TUNNELFACE"/>
-      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportLocation_USERDEFINED" name="USERDEFINED"/>
-      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportLocation_NOTDEFINED" name="NOTDEFINED"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportLocation_TUNNEL_VAULT" name="TUNNEL_VAULT"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportLocation_TUNNEL_FACE" name="TUNNEL_FACE"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportLocation_OTHER" name="OTHER"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportLocation_NOTKNOWN" name="NOTKNOWN"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportLocation_UNSET" name="UNSET"/>
     </packagedElement>
     <packagedElement xmi:type="uml:Enumeration" xmi:id="en_PEnum_PreSupportType" name="PEnum_PreSupportType">
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportType_JETGROUTED" name="JETGROUTED"/>

--- a/schemas/IfcSharedInfrastructureElements.uml
+++ b/schemas/IfcSharedInfrastructureElements.uml
@@ -1271,5 +1271,255 @@
       <supplier xmi:type="uml:Class" href="IfcStructuralElementsDomain.uml#cl_IfcSurfaceFeature"/>
     </packagedElement>
     <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Qto_VolumetricStratumBaseQuantities_IfcGeotechnicalStratum" client="cl_Qto_VolumetricStratumBaseQuantities" supplier="cl_IfcGeotechnicalStratum"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_GeoAspects" name="Pset_GeoAspects">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_GeoAspects_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoAspects_AsbestosPotential" name="AsbestosPotential">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcText"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoAspects_AsbestosPotential_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoAspects_AsbestosPotential_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoAspects_Boulders" name="Boulders">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcText"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoAspects_Boulders_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoAspects_Boulders_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoAspects_CloggingPotential" name="CloggingPotential">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcText"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoAspects_CloggingPotential_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoAspects_CloggingPotential_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoAspects_Contamination" name="Contamination">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoAspects_Contamination_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoAspects_Contamination_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoAspects_DumpCategory" name="DumpCategory">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoAspects_DumpCategory_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoAspects_DumpCategory_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoAspects_GasConcentration" name="GasConcentration">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoAspects_GasConcentration_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoAspects_GasConcentration_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoAspects_GasType" name="GasType">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoAspects_GasType_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoAspects_GasType_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoAspects_GroundTemperature" name="GroundTemperature">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcThermodynamicTemperatureMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoAspects_GroundTemperature_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoAspects_GroundTemperature_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoAspects_GroundwaterAgressiveness" name="GroundwaterAgressiveness">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoAspects_GroundwaterAgressiveness_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoAspects_GroundwaterAgressiveness_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoAspects_GroundwaterDesignPressure" name="GroundwaterDesignPressure">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPressureMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoAspects_GroundwaterDesignPressure_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoAspects_GroundwaterDesignPressure_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoAspects_GroundwaterTemperature" name="GroundwaterTemperature">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcThermodynamicTemperatureMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoAspects_GroundwaterTemperature_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoAspects_GroundwaterTemperature_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoAspects_HeavyMetalsPotential" name="HeavyMetalsPotential">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcText"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoAspects_HeavyMetalsPotential_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoAspects_HeavyMetalsPotential_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoAspects_InSituStress" name="InSituStress">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPressureMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoAspects_InSituStress_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoAspects_InSituStress_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoAspects_Karst" name="Karst">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcText"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoAspects_Karst_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoAspects_Karst_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoAspects_MaxGroundwaterInflow" name="MaxGroundwaterInflow">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcVolumetricFlowRateMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoAspects_MaxGroundwaterInflow_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoAspects_MaxGroundwaterInflow_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoAspects_Overburden" name="Overburden">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPositiveLengthMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoAspects_Overburden_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoAspects_Overburden_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoAspects_Swelling" name="Swelling">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoAspects_Swelling_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoAspects_Swelling_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_GeoAspects_IfcTunnelTypicalSectionTypeEnum_GEOTECH" client="cl_Pset_GeoAspects">
+      <supplier xmi:type="uml:Class" href="IfcTunnelDomain.uml#cl_IfcTunnelTypicalSectionTypeEnum_GEOTECH"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_PreSupportCommon" name="Pset_PreSupportCommon">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_PreSupportCommon_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_PreSupportCommon_AreHolesGrouted" name="AreHolesGrouted">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcBoolean"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_PreSupportCommon_AreHolesGrouted_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_PreSupportCommon_AreHolesGrouted_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_PreSupportCommon_Arrangement" name="Arrangement" type="en_PEnum_PreSupportArrangement">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_PreSupportCommon_Arrangement_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_PreSupportCommon_Arrangement_upper" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_PreSupportCommon_BoreholeLengthPlanned" name="BoreholeLengthPlanned">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPositiveLengthMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_PreSupportCommon_BoreholeLengthPlanned_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_PreSupportCommon_BoreholeLengthPlanned_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_PreSupportCommon_BoreholeOverlap" name="BoreholeOverlap">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLengthMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_PreSupportCommon_BoreholeOverlap_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_PreSupportCommon_BoreholeOverlap_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_PreSupportCommon_DrillingDiameter" name="DrillingDiameter">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPositiveLengthMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_PreSupportCommon_DrillingDiameter_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_PreSupportCommon_DrillingDiameter_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_PreSupportCommon_DrillingMethod" name="DrillingMethod">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_PreSupportCommon_DrillingMethod_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_PreSupportCommon_DrillingMethod_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_PreSupportCommon_IsBoreholeCased" name="IsBoreholeCased">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcBoolean"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_PreSupportCommon_IsBoreholeCased_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_PreSupportCommon_IsBoreholeCased_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_PreSupportCommon_PreSupportLocation" name="PreSupportLocation" type="en_PEnum_PreSupportLocation">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_PreSupportCommon_PreSupportLocation_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_PreSupportCommon_PreSupportLocation_upper" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_PreSupportCommon_PreSupportType" name="PreSupportType" type="en_PEnum_PreSupportType">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_PreSupportCommon_PreSupportType_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_PreSupportCommon_PreSupportType_upper" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_PreSupportCommon_UsefulLength" name="UsefulLength">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLengthMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_PreSupportCommon_UsefulLength_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_PreSupportCommon_UsefulLength_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_PreSupportCommon_UserDefinedPreSupportLocation" name="UserDefinedPreSupportLocation">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_PreSupportCommon_UserDefinedPreSupportLocation_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_PreSupportCommon_UserDefinedPreSupportLocation_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_PreSupportCommon_UserDefinedPreSupportType" name="UserDefinedPreSupportType">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_PreSupportCommon_UserDefinedPreSupportType_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_PreSupportCommon_UserDefinedPreSupportType_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Enumeration" xmi:id="en_PEnum_PreSupportArrangement" name="PEnum_PreSupportArrangement">
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportArrangement_SIMPLE" name="SIMPLE"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportArrangement_STAGGERED" name="STAGGERED"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Enumeration" xmi:id="en_PEnum_PreSupportLocation" name="PEnum_PreSupportLocation">
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportLocation_TUNNELVAULT" name="TUNNELVAULT"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportLocation_TUNNELFACE" name="TUNNELFACE"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportLocation_USERDEFINED" name="USERDEFINED"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportLocation_NOTDEFINED" name="NOTDEFINED"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Enumeration" xmi:id="en_PEnum_PreSupportType" name="PEnum_PreSupportType">
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportType_JETGROUTED" name="JETGROUTED"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportType_PIPEUMBRELLA" name="PIPEUMBRELLA"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportType_FREEZING" name="FREEZING"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportType_FOREPOLING" name="FOREPOLING"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportType_SPILING" name="SPILING"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportType_USERDEFINED" name="USERDEFINED"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportType_NOTDEFINED" name="NOTDEFINED"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_PreSupportCommon_IfcBuiltSystemTypeEnum_TUNNEL_PRESUPPORT" client="cl_Pset_PreSupportCommon">
+      <supplier xmi:type="uml:Class" href="IfcProductExtension.uml#cl_IfcBuiltSystemTypeEnum_TUNNEL_PRESUPPORT"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_PreSupportCommon_IfcTunnelTypicalSectionTypeEnum_EXCAVATIONSUPPORT" client="cl_Pset_PreSupportCommon">
+      <supplier xmi:type="uml:Class" href="IfcTunnelDomain.uml#cl_IfcTunnelTypicalSectionTypeEnum_EXCAVATIONSUPPORT"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_PreSupportCommon_IfcElementAssemblyTypeEnum_PRESUPPORTVAULT" client="cl_Pset_PreSupportCommon">
+      <supplier xmi:type="uml:Class" href="IfcProductExtension.uml#cl_IfcElementAssemblyTypeEnum_PRESUPPORTVAULT"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_PreSupportCommon_IfcElementAssemblyTypeEnum_PRESUPPORTFACE" client="cl_Pset_PreSupportCommon">
+      <supplier xmi:type="uml:Class" href="IfcProductExtension.uml#cl_IfcElementAssemblyTypeEnum_PRESUPPORTFACE"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_SupportCommon" name="Pset_SupportCommon">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_SupportCommon_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_SupportCommon_Arrangement" name="Arrangement">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_SupportCommon_Arrangement_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_SupportCommon_Arrangement_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_SupportCommon_GroutingType" name="GroutingType" type="en_PEnum_GroutingType">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_SupportCommon_GroutingType_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_SupportCommon_GroutingType_upper" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_SupportCommon_HorizontalSpacing" name="HorizontalSpacing">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPositiveLengthMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_SupportCommon_HorizontalSpacing_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_SupportCommon_HorizontalSpacing_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_SupportCommon_LongitudinalSpacing" name="LongitudinalSpacing">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPositiveLengthMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_SupportCommon_LongitudinalSpacing_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_SupportCommon_LongitudinalSpacing_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_SupportCommon_NumberOfBolts" name="NumberOfBolts">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcCountMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_SupportCommon_NumberOfBolts_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_SupportCommon_NumberOfBolts_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_SupportCommon_PlateType" name="PlateType">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_SupportCommon_PlateType_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_SupportCommon_PlateType_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_SupportCommon_RadialSpacing" name="RadialSpacing">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPositiveLengthMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_SupportCommon_RadialSpacing_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_SupportCommon_RadialSpacing_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_SupportCommon_UserDefinedGroutingType" name="UserDefinedGroutingType">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_SupportCommon_UserDefinedGroutingType_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_SupportCommon_UserDefinedGroutingType_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_SupportCommon_VerticalSpacing" name="VerticalSpacing">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPositiveLengthMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_SupportCommon_VerticalSpacing_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_SupportCommon_VerticalSpacing_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Enumeration" xmi:id="en_PEnum_GroutingType" name="PEnum_GroutingType">
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GroutingType_STDGROUTING_CEMENT" name="STDGROUTING_CEMENT"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GroutingType_MICROFINE_CEMENT" name="MICROFINE_CEMENT"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GroutingType_ULTRAFINE_CEMENT" name="ULTRAFINE_CEMENT"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GroutingType_CHEMICAL_COMPONENT" name="CHEMICAL_COMPONENT"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GroutingType_USERDEFINED" name="USERDEFINED"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GroutingType_NOTKNOWN" name="NOTKNOWN"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GroutingType_UNSET" name="UNSET"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_SupportCommon_IfcBuiltSystemTypeEnum_TUNNEL_SUPPORT" client="cl_Pset_SupportCommon">
+      <supplier xmi:type="uml:Class" href="IfcProductExtension.uml#cl_IfcBuiltSystemTypeEnum_TUNNEL_SUPPORT"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_SupportCommon_IfcTunnelTypicalSectionTypeEnum_EXCAVATIONSUPPORT" client="cl_Pset_SupportCommon">
+      <supplier xmi:type="uml:Class" href="IfcTunnelDomain.uml#cl_IfcTunnelTypicalSectionTypeEnum_EXCAVATIONSUPPORT"/>
+    </packagedElement>
   </packagedElement>
 </uml:Model>

--- a/schemas/IfcSharedInfrastructureElements.uml
+++ b/schemas/IfcSharedInfrastructureElements.uml
@@ -1507,11 +1507,11 @@
       </ownedAttribute>
     </packagedElement>
     <packagedElement xmi:type="uml:Enumeration" xmi:id="en_PEnum_GroutingType" name="PEnum_GroutingType">
-      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GroutingType_STDGROUTING_CEMENT" name="STDGROUTING_CEMENT"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GroutingType_STANDARD_GROUTING_CEMENT" name="STANDARD_GROUTING_CEMENT"/>
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GroutingType_MICROFINE_CEMENT" name="MICROFINE_CEMENT"/>
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GroutingType_ULTRAFINE_CEMENT" name="ULTRAFINE_CEMENT"/>
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GroutingType_CHEMICAL_COMPONENT" name="CHEMICAL_COMPONENT"/>
-      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GroutingType_USERDEFINED" name="USERDEFINED"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GroutingType_OTHER" name="OTHER"/>
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GroutingType_NOTKNOWN" name="NOTKNOWN"/>
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GroutingType_UNSET" name="UNSET"/>
     </packagedElement>

--- a/schemas/IfcSharedInfrastructureElements.uml
+++ b/schemas/IfcSharedInfrastructureElements.uml
@@ -1466,8 +1466,7 @@
       <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_SupportCommon_comment_0">
         <body>PSET_TYPEDRIVENOVERRIDE</body>
       </ownedComment>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_SupportCommon_Arrangement" name="Arrangement">
-        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_SupportCommon_Arrangement" name="Arrangement" type="en_PEnum_PreSupportArrangement">
         <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_SupportCommon_Arrangement_lower"/>
         <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_SupportCommon_Arrangement_upper" value="1"/>
       </ownedAttribute>

--- a/schemas/IfcSharedInfrastructureElements.uml
+++ b/schemas/IfcSharedInfrastructureElements.uml
@@ -1429,6 +1429,9 @@
     <packagedElement xmi:type="uml:Enumeration" xmi:id="en_PEnum_PreSupportArrangement" name="PEnum_PreSupportArrangement">
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportArrangement_SIMPLE" name="SIMPLE"/>
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportArrangement_STAGGERED" name="STAGGERED"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportArrangement_OTHER" name="OTHER"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportArrangement_NOTKNOWN" name="NOTKNOWN"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportArrangement_UNSET" name="UNSET"/>
     </packagedElement>
     <packagedElement xmi:type="uml:Enumeration" xmi:id="en_PEnum_PreSupportLocation" name="PEnum_PreSupportLocation">
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportLocation_TUNNELVAULT" name="TUNNELVAULT"/>

--- a/schemas/IfcSharedInfrastructureElements.uml
+++ b/schemas/IfcSharedInfrastructureElements.uml
@@ -1441,13 +1441,14 @@
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportLocation_UNSET" name="UNSET"/>
     </packagedElement>
     <packagedElement xmi:type="uml:Enumeration" xmi:id="en_PEnum_PreSupportType" name="PEnum_PreSupportType">
-      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportType_JETGROUTED" name="JETGROUTED"/>
-      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportType_PIPEUMBRELLA" name="PIPEUMBRELLA"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportType_JET_GROUTED" name="JET_GROUTED"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportType_PIPE_UMBRELLA" name="PIPE_UMBRELLA"/>
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportType_FREEZING" name="FREEZING"/>
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportType_FOREPOLING" name="FOREPOLING"/>
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportType_SPILING" name="SPILING"/>
-      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportType_USERDEFINED" name="USERDEFINED"/>
-      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportType_NOTDEFINED" name="NOTDEFINED"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportType_OTHER" name="OTHER"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportType_NOTKNOWN" name="NOTKNOWN"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_PreSupportType_UNSET" name="UNSET"/>
     </packagedElement>
     <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_PreSupportCommon_IfcBuiltSystemTypeEnum_TUNNEL_PRESUPPORT" client="cl_Pset_PreSupportCommon">
       <supplier xmi:type="uml:Class" href="IfcProductExtension.uml#cl_IfcBuiltSystemTypeEnum_TUNNEL_PRESUPPORT"/>

--- a/schemas/IfcTunnelDomain.uml
+++ b/schemas/IfcTunnelDomain.uml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uml:Model xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="md_IfcTunnelDomain" name="IfcTunnelDomain">
+  <packagedElement xmi:type="uml:Package" xmi:id="pk_IfcTunnelDomain" name="IfcTunnelDomain">
+    <packagedElement xmi:type="uml:Enumeration" xmi:id="en_IfcTunnelTypicalSectionTypeEnum" name="IfcTunnelTypicalSectionTypeEnum">
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcTunnelTypicalSectionTypeEnum_GEOTECH" name="GEOTECH"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcTunnelTypicalSectionTypeEnum_EXCAVATIONSUPPORT" name="EXCAVATIONSUPPORT"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcTunnelTypicalSectionTypeEnum_RISK" name="RISK"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcTunnelTypicalSectionTypeEnum_USERDEFINED" name="USERDEFINED"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcTunnelTypicalSectionTypeEnum_NOTDEFINED" name="NOTDEFINED"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcTunnelTypicalSection" name="IfcTunnelTypicalSection">
+      <ownedRule xmi:type="uml:Constraint" xmi:id="ct_IfcTunnelTypicalSection_HasObjectType" name="HasObjectType">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="cl_IfcTunnelTypicalSection_HasObjectType" name="HasObjectType">
+          <language>EXPRESS_WHERE</language>
+          <body>(PredefinedType &lt;> IfcTunnelTypicalSectionTypeEnum.USERDEFINED) OR EXISTS(SELF\IfcObject.ObjectType)</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcTunnelTypicalSection_gen_IfcLinearZone">
+        <general xmi:type="uml:Class" href="IfcProductExtension.uml#cl_IfcLinearZone"/>
+      </generalization>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcTunnelTypicalSection_PredefinedType" name="PredefinedType" type="en_IfcTunnelTypicalSectionTypeEnum">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcTunnelTypicalSection_PredefinedType_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcTunnelTypicalSection_PredefinedType_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcTunnelTypicalSectionTypeEnum_GEOTECH" name="IfcTunnelTypicalSectionTypeEnum.GEOTECH">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcTunnelTypicalSectionTypeEnum_GEOTECH_gen_IfcTunnelTypicalSection" general="cl_IfcTunnelTypicalSection"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcTunnelTypicalSectionTypeEnum_EXCAVATIONSUPPORT" name="IfcTunnelTypicalSectionTypeEnum.EXCAVATIONSUPPORT">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcTunnelTypicalSectionTypeEnum_EXCAVATIONSUPPORT_gen_IfcTunnelTypicalSection" general="cl_IfcTunnelTypicalSection"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcTunnelTypicalSectionTypeEnum_RISK" name="IfcTunnelTypicalSectionTypeEnum.RISK">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcTunnelTypicalSectionTypeEnum_RISK_gen_IfcTunnelTypicalSection" general="cl_IfcTunnelTypicalSection"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcTunnelTypicalSectionTypeEnum_USERDEFINED" name="IfcTunnelTypicalSectionTypeEnum.USERDEFINED">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcTunnelTypicalSectionTypeEnum_USERDEFINED_gen_IfcTunnelTypicalSection" general="cl_IfcTunnelTypicalSection"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcTunnelTypicalSectionTypeEnum_NOTDEFINED" name="IfcTunnelTypicalSectionTypeEnum.NOTDEFINED">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcTunnelTypicalSectionTypeEnum_NOTDEFINED_gen_IfcTunnelTypicalSection" general="cl_IfcTunnelTypicalSection"/>
+    </packagedElement>
+  </packagedElement>
+</uml:Model>

--- a/schemas/ifc4x3_add2.uml
+++ b/schemas/ifc4x3_add2.uml
@@ -126,6 +126,9 @@
   <packageImport xmi:type="uml:PackageImport" xmi:id="ip_IfcRailDomain">
     <importedPackage xmi:type="uml:Package" href="IfcRailDomain.uml#pk_IfcRailDomain"/>
   </packageImport>
+  <packageImport xmi:type="uml:PackageImport" xmi:id="ip_IfcTunnelDomain">
+    <importedPackage xmi:type="uml:Package" href="IfcTunnelDomain.uml#pk_IfcTunnelDomain"/>
+  </packageImport>
   <packageImport xmi:type="uml:PackageImport" xmi:id="ip_propertytypes">
     <importedPackage xmi:type="uml:Package" href="propertytypes.uml#pk_propertytypes"/>
   </packageImport>


### PR DESCRIPTION

- ENTITY IfcLinearZone (abstract, subtype of IfcLinearElement) — in IfcProductExtension
- ENTITY IfcTunnelTypicalSection (subtype of IfcLinearZone) — in IfcTunnelDomain (new schema)
- TYPE IfcTunnelTypicalSectionTypeEnum (GEOTECH, EXCAVATIONSUPPORT, RISK, USERDEFINED, NOTDEFINED)

Bundled property delivery:
- Pset_GeoAspects (GEOTECH, 17 properties)
- Pset_PreSupportCommon (EXCAVATIONSUPPORT, 12 properties)
- Pset_SupportCommon (EXCAVATIONSUPPORT, 9 properties)
- PEnum_GroutingType, PEnum_PreSupportArrangement, PEnum_PreSupportLocation, PEnum_PreSupportType

Plus the 4 IFC 4.4 enum-literal extensions to IfcBuiltSystemTypeEnum (TUNNEL_PRESUPPORT, TUNNEL_SUPPORT) and IfcElementAssemblyTypeEnum (PRESUPPORTVAULT, PRESUPPORTFACE).

[ED] overlays:
- 4 commits harmonize PEnum literals to OTHER/NOTKNOWN/UNSET tail per project convention
- 1 commit aligns Pset_SupportCommon.Arrangement to PEnum_PreSupportArrangement